### PR TITLE
"Causal" Transformer embeddings

### DIFF
--- a/egg/core/transformer.py
+++ b/egg/core/transformer.py
@@ -56,7 +56,7 @@ class TransformerEncoder(torch.nn.Module):
     def init_parameters(self):
         nn.init.normal_(self.embedding.weight, mean=0, std=self.embed_dim ** -0.5)
 
-    def forward(self, src_tokens, encoder_padding_mask=None):
+    def forward(self, src_tokens, key_padding_mask=None, attn_mask=None):
         # embed tokens and positions
         x = self.embed_scale * self.embedding(src_tokens)
 
@@ -69,7 +69,7 @@ class TransformerEncoder(torch.nn.Module):
 
         # encoder layers
         for layer in self.layers:
-            x = layer(x, encoder_padding_mask)
+            x = layer(x, key_padding_mask, attn_mask)
 
         x = self.layer_norm(x)
 
@@ -99,10 +99,10 @@ class TransformerEncoderLayer(nn.Module):
 
         self.init_parameters()
 
-    def forward(self, x, encoder_padding_mask):
+    def forward(self, x, key_padding_mask=None, attn_mask=None):
         residual = x
         x = self.self_attn_layer_norm(x)
-        x, _att = self.self_attn(query=x, key=x, value=x, key_padding_mask=encoder_padding_mask)
+        x, _att = self.self_attn(query=x, key=x, value=x, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
         x = F.dropout(x, p=self.dropout, training=self.training)
         x = residual + x
 

--- a/egg/zoo/channel/train.py
+++ b/egg/zoo/channel/train.py
@@ -150,7 +150,7 @@ def main(params):
         receiver = Receiver(n_features=opts.n_features, n_hidden=opts.receiver_embedding)
         receiver = core.TransformerReceiverDeterministic(receiver, opts.vocab_size, opts.max_len,
                                                          opts.receiver_embedding, opts.receiver_num_heads, opts.receiver_hidden,
-                                                         opts.receiver_num_layers)
+                                                         opts.receiver_num_layers, causal=opts.causal_receiver)
     else:
         receiver = Receiver(n_features=opts.n_features, n_hidden=opts.receiver_hidden)
         receiver = core.RnnReceiverDeterministic(receiver, opts.vocab_size, opts.receiver_embedding,

--- a/egg/zoo/channel/train.py
+++ b/egg/zoo/channel/train.py
@@ -42,6 +42,9 @@ def get_params(params):
     parser.add_argument('--receiver_embedding', type=int, default=10,
                         help='Dimensionality of the embedding hidden layer for Receiver (default: 10)')
 
+    parser.add_argument('--causal_sender', default=False, action='store_true')
+    parser.add_argument('--causal_receiver', default=False, action='store_true')
+
     parser.add_argument('--sender_generate_style', type=str, default='in-place', choices=['standard', 'in-place'],
                         help='How the next symbol is generated within the TransformerDecoder (default: in-place)')
 
@@ -134,7 +137,8 @@ def main(params):
                                                  opts.sender_num_layers, opts.sender_num_heads,
                                                  ffn_embed_dim=opts.sender_hidden,
                                                  force_eos=opts.force_eos,
-                                                 generate_style=opts.sender_generate_style)
+                                                 generate_style=opts.sender_generate_style,
+                                                 causal=opts.causal_sender)
     else:
         sender = Sender(n_features=opts.n_features, n_hidden=opts.sender_hidden)
 


### PR DESCRIPTION
An optional flag that makes embeddings of individual terms depend only on the symbols on the left.
* Sender logic barely changes, only adding a mask
* Receiver logic although does change more substantially