### PR TITLE
New callback API

### DIFF
--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .trainers import Trainer
+from .callbacks import Callback, ConsoleLogger, TensorboardLogger
 from .util import init, get_opts, build_optimizer, dump_sender_receiver, move_to, get_summary_writer, close
 from egg.core.early_stopping import BaseEarlyStopper, EarlyStopperAccuracy
 from .gs_wrappers import (GumbelSoftmaxWrapper,
@@ -17,11 +18,15 @@ from .reinforce_wrappers import (ReinforceWrapper, SymbolGameReinforce,
                                  RnnReceiverDeterministic, TransformerReceiverDeterministic,
                                  TransformerSenderReinforce)
 
+
 __all__ = [
     'Trainer',
     'get_opts',
     'init',
     'build_optimizer',
+    'Callback',
+    'ConsoleLogger',
+    'TensorboardLogger',
     'ReinforceWrapper',
     'GumbelSoftmaxWrapper',
     'SymbolGameGS',

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -1,0 +1,80 @@
+import json
+from typing import Dict, Any
+
+from egg.core.util import get_summary_writer
+
+
+class Callback:
+    trainer: 'Trainer'
+
+    def on_train_begin(self, trainer_instance: 'Trainer'):
+        self.trainer = trainer_instance
+
+    def on_train_end(self):
+        pass
+
+    def on_test_begin(self):
+        pass
+
+    def on_test_end(self, loss: float, logs: Dict[str, Any] = None):
+        pass
+
+    def on_epoch_begin(self):
+        pass
+
+    def on_epoch_end(self, loss: float, logs: Dict[str, Any] = None):
+        pass
+
+
+class ConsoleLogger(Callback):
+
+    def __init__(self, print_train_loss=False, as_json=False):
+        self.print_train_loss = print_train_loss
+        self.as_json = as_json
+        self.epoch_counter = 0
+
+    def on_test_end(self, loss: float, logs: Dict[str, Any] = None):
+        if self.as_json:
+            dump = dict(mode='test', epoch=self.epoch_counter, loss=loss.mean().item())
+            for k, v in logs.items():
+                dump[k] = v.item() if hasattr(v, 'item') else v
+            output_message = json.dumps(dump)
+        else:
+            output_message = f'test: epoch {self.epoch_counter}, loss {loss},  {logs}'
+        print(output_message, flush=True)
+
+    def on_epoch_end(self, loss: float, logs: Dict[str, Any] = None):
+        self.epoch_counter += 1
+        if self.print_train_loss:
+            if self.as_json:
+                dump = dict(mode='train', epoch=self.epoch_counter, loss=loss.mean().item())
+                for k, v in logs.items():
+                    dump[k] = v.item() if hasattr(v, 'item') else v
+                output_message = json.dumps(dump)
+            else:
+                output_message = f'train: epoch {self.epoch_counter}, loss {loss},  {logs}'
+            print(output_message, flush=True)
+
+
+class TensorboardLogger(Callback):
+
+    def __init__(self, writer=None):
+        if writer:
+            self.writer = writer
+        else:
+            self.writer = get_summary_writer
+        self.epoch_counter = 0
+
+    def on_test_end(self, loss: float, logs: Dict[str, Any] = None):
+        self.writer.add_scalar(tag=f'test/loss', scalar_value=loss.mean(), global_step=self.epoch)
+        for k, v in logs.items():
+            self.writer.add_scalar(tag=f'test/{k}', scalar_value=v, global_step=self.epoch)
+
+    def on_epoch_end(self, loss: float, logs: Dict[str, Any] = None):
+        self.epoch_counter += 1
+        self.writer.add_scalar(tag=f'train/loss', scalar_value=loss.mean(), global_step=self.epoch)
+        for k, v in logs.items():
+            self.writer.add_scalar(tag=f'train/{k}', scalar_value=v, global_step=self.epoch)
+
+    def on_train_end(self):
+        self.writer.close()

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -3,12 +3,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
-import torch
-from .util import get_opts, move_to, get_summary_writer
-import pathlib
 import os
 import uuid
+import pathlib
+from typing import List, Optional, Callable
+
+import torch
+from torch.utils.data import DataLoader
+
+from .util import get_opts, move_to
+from .callbacks import Callback, ConsoleLogger
+from .early_stopping import BaseEarlyStopper
+
 
 
 def _add_dicts(a, b):
@@ -30,8 +36,17 @@ class Trainer:
     Implements the training logic. Some common configuration (checkpointing frequency, path, validation frequency)
     is done by checking util.common_opts that is set via the CL.
     """
-    def __init__(self, game, optimizer, train_data, validation_data=None, device=None, epoch_callback=None,
-                 as_json=False, early_stopping=None, print_train_loss=False):
+    def __init__(
+            self,
+            game: torch.nn.Module,
+            optimizer: torch.optim.Optimizer,
+            train_data: DataLoader,
+            validation_data: Optional[DataLoader] = None,
+            device: torch.device = None,
+            epoch_callback: Callable = None,  # TODO: deprecate in favor of the new callback API
+            early_stopping: BaseEarlyStopper = None,  # TODO: deprecate in favor of the new callback API
+            callbacks: Optional[List[Callback]] = None
+    ):
         """
         :param game: A nn.Module that implements forward(); it is expected that forward returns a tuple of (loss, d),
             where loss is differentiable loss to be minimized and d is a dictionary (potentially empty) with auxiliary
@@ -39,10 +54,12 @@ class Trainer:
         :param optimizer: An instance of torch.optim.Optimizer
         :param train_data: A DataLoader for the training set
         :param validation_data: A DataLoader for the validation set (can be None)
+        :param device: A torch.device on which to tensors should be stored
         :param epoch_callback: A callable that would be called at the end of each epoch (after validation, can be None).
         :param as_json: Output validation statistics as json
         :param early_stopping: An instance that defines the stopping logic. Called after every run on validation data;
             see early_stopping.py for an example.
+        :param callbacks: A list of egg.core.Callback objects that can encapsulate monitoring or checkpointing
         """
         self.game = game
         self.optimizer = optimizer
@@ -54,11 +71,8 @@ class Trainer:
         self.checkpoint_freq = common_opts.checkpoint_freq
         self.device = common_opts.device if device is None else device
         self.game.to(self.device)
-        self.as_json = as_json
         self.early_stopping = early_stopping
-        self.print_train_loss = print_train_loss
-
-        self.epoch = 0
+        self.callbacks = callbacks
 
         if common_opts.load_from_checkpoint is not None:
             print(f"# Initializing model, trainer, and optimizer from {common_opts.load_from_checkpoint}")
@@ -72,6 +86,12 @@ class Trainer:
         else:
             self.checkpoint_path = None if common_opts.checkpoint_dir is None \
                 else pathlib.Path(common_opts.checkpoint_dir)
+
+        self.should_stop = False  # Attribute to be manipulated by callbacks
+        if self.callbacks is None:
+            self.callbacks = [
+                ConsoleLogger(print_train_loss=False, as_json=False),
+            ]
 
     def _get_preemptive_checkpoint_dir(self, checkpoint_root):
         if 'SLURM_JOB_ID' not in os.environ:
@@ -124,44 +144,49 @@ class Trainer:
         return mean_loss, mean_rest
 
     def train(self, n_epochs):
-        def _message(mode, epoch, loss, rest, as_json):
-            writer = get_summary_writer()
-            if writer:
-                writer.add_scalar(tag=f'{mode}/loss', scalar_value=loss.mean(), global_step=epoch)
-                for k, v in rest.items():
-                    writer.add_scalar(tag=f'{mode}/{k}', scalar_value=v, global_step=epoch)
-            if as_json:
-                dump = dict(mode=mode, epoch=epoch, loss=loss.mean().item())
-                for k, v in rest.items(): dump[k] = v.item() if hasattr(v, 'item') else v
-                output_message = json.dumps(dump)
-            else:
-                output_message = f'{mode}: epoch {self.epoch}, loss {loss},  {rest}'
-            print(output_message, flush=True)
+        for callback in self.callbacks:
+            callback.on_train_begin(self)
 
-        while self.epoch < n_epochs:
+        for epoch in range(n_epochs):
+            self.epoch = epoch  # TODO: deprecate this attribute in favor of the new callback API
+            for callback in self.callbacks:
+                callback.on_epoch_begin()
+
             train_loss, train_rest = self.train_epoch()
 
-            self.epoch += 1
+            for callback in self.callbacks:
+                callback.on_epoch_end(train_loss, train_rest)
 
+            # TODO: the logic below is to be reimplemented using the new callback API
             if self.epoch_callback:
                 self.epoch_callback(self)
-
             if self.checkpoint_freq > 0 and (self.epoch % self.checkpoint_freq == 0) and self.checkpoint_path:
                 self.save_checkpoint()
+            # TODO: the logic above is to be reimplemented using the new callback API
 
-            if self.print_train_loss:
-                _message('train', self.epoch, train_loss, train_rest, self.as_json)
-
-            if self.validation_data is not None and self.validation_freq > 0 and self.epoch % self.validation_freq == 0:
+            if self.validation_data is not None and self.validation_freq > 0 and epoch % self.validation_freq == 0:
+                for callback in self.callbacks:
+                    callback.on_test_begin()
                 validation_loss, rest = self.eval()
-                _message('validation', self.epoch, validation_loss, rest, self.as_json)
+                for callback in self.callbacks:
+                    callback.on_test_end(validation_loss, rest)
 
+                # TODO: the logic below is to be reimplemented using the new callback API
                 if self.early_stopping:
                     self.early_stopping.update_values(validation_loss, rest, train_loss, rest, self.epoch)
                     if self.early_stopping.should_stop(): break
+                # TODO: the logic above is to be reimplemented using the new callback API
 
+            if self.should_stop:
+                break
+
+        # TODO: the logic below is to be reimplemented using the new callback API
         if self.checkpoint_path:
             self.save_checkpoint()
+        # TODO: the logic above is to be reimplemented using the new callback API
+
+        for callback in self.callbacks:
+            callback.on_train_end()
 
     def save_checkpoint(self, name=''):
         """

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -87,7 +87,6 @@ class Trainer:
             self.checkpoint_path = None if common_opts.checkpoint_dir is None \
                 else pathlib.Path(common_opts.checkpoint_dir)
 
-        self.should_stop = False  # Attribute to be manipulated by callbacks
         if self.callbacks is None:
             self.callbacks = [
                 ConsoleLogger(print_train_loss=False, as_json=False),
@@ -176,9 +175,6 @@ class Trainer:
                     self.early_stopping.update_values(validation_loss, rest, train_loss, rest, self.epoch)
                     if self.early_stopping.should_stop(): break
                 # TODO: the logic above is to be reimplemented using the new callback API
-
-            if self.should_stop:
-                break
 
         # TODO: the logic below is to be reimplemented using the new callback API
         if self.checkpoint_path:

--- a/egg/zoo/language_bottleneck/guess_number/train.py
+++ b/egg/zoo/language_bottleneck/guess_number/train.py
@@ -123,8 +123,8 @@ def main(params):
     early_stopper = EarlyStopperAccuracy(opts.early_stopping_thr)
 
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=intervention, as_json=True,
-                           early_stopping=early_stopper)
+                           validation_data=test_loader, epoch_callback=intervention,
+                           early_stopping=early_stopper, callbacks=[core.ConsoleLogger(as_json=True)])
 
     trainer.train(n_epochs=opts.n_epochs)
 

--- a/egg/zoo/language_bottleneck/mnist_adv/train.py
+++ b/egg/zoo/language_bottleneck/mnist_adv/train.py
@@ -75,9 +75,9 @@ def main(params):
     early_stopper = EarlyStopperAccuracy(opts.early_stopping_thr)
 
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, as_json=True,
+                           validation_data=test_loader,
                            early_stopping=early_stopper,
-                           print_train_loss=True)
+                           callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=True)])
 
     trainer.train(n_epochs=opts.n_epochs)
     core.close()

--- a/egg/zoo/language_bottleneck/mnist_classification/train.py
+++ b/egg/zoo/language_bottleneck/mnist_classification/train.py
@@ -79,8 +79,8 @@ def main(params):
                                      input_intervention=True)
 
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=intervention, as_json=True,
-                           early_stopping=early_stopper)
+                           validation_data=test_loader, epoch_callback=intervention,
+                           early_stopping=early_stopper, callbacks=[core.ConsoleLogger(as_json=True)])
 
     trainer.train(n_epochs=opts.n_epochs)
     core.close()

--- a/egg/zoo/language_bottleneck/mnist_overfit/train.py
+++ b/egg/zoo/language_bottleneck/mnist_overfit/train.py
@@ -90,9 +90,10 @@ def main(params):
     early_stopper = EarlyStopperAccuracy(opts.early_stopping_thr)
 
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, as_json=True,
+                           validation_data=test_loader,
                            early_stopping=early_stopper,
-                           print_train_loss=True)
+                           callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=True)]
+                           )
 
     trainer.train(n_epochs=opts.n_epochs)
     core.close()

--- a/egg/zoo/objects_game/train.py
+++ b/egg/zoo/objects_game/train.py
@@ -178,7 +178,8 @@ if __name__ == "__main__":
     ])
 
     trainer = core.Trainer(game=game, optimizer=optimizer,
-                           train_data=train_data, validation_data=validation_data, epoch_callback=callback, as_json=opts.output_json)
+                           train_data=train_data, validation_data=validation_data, epoch_callback=callback,
+                           callbacks=[core.ConsoleLogger(as_json=True)])
     trainer.train(n_epochs=opts.n_epochs)
 
     if opts.evaluate:

--- a/egg/zoo/simple_autoenc/train.py
+++ b/egg/zoo/simple_autoenc/train.py
@@ -103,7 +103,8 @@ if __name__ == "__main__":
     ])
 
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=callback)
+                           validation_data=test_loader, epoch_callback=callback,
+                           callbacks=[core.ConsoleLogger(as_json=True)])
     trainer.train(n_epochs=opts.n_epochs)
 
     core.close()

--- a/egg/zoo/simple_autoenc/train.py
+++ b/egg/zoo/simple_autoenc/train.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     ])
 
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=callback, print_train_loss=True)
+                           validation_data=test_loader, epoch_callback=callback)
     trainer.train(n_epochs=opts.n_epochs)
 
     core.close()


### PR DESCRIPTION
As discussed in #7, I'm opening a pull request with a new Callback API. This pull request:
1. Implements the agreed upon interface for the API
2. Remplements the monitoring logic (console printing and Tensorboard logging) as callbacks
3. Changes the calls to the `Trainer` in `zoo` examples to conform to the new API
4. Minor changes: add some `typing`, reorder imports to conform PEP8, add missing documentation

I decided to leave checkpointing, early stopping and current `epoch_callback` as-is to keep this pull request (and code review) tractable. I've marked as TODO the lines of code in the `Trainer` that are to be reimplemented using the new callback API and will be happy to work on that after this pull request gets merged.

PS. Current master fails a doc-test in `early_stopping.py`. I can fix it when working on porting early stopper to the new API.