### PR TITLE
Move remaining trainer functionality to the new callback API

### DIFF
--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -6,7 +6,7 @@
 from .trainers import Trainer
 from .callbacks import Callback, ConsoleLogger, TensorboardLogger, TemperatureUpdater, CheckpointSaver
 from .util import init, get_opts, build_optimizer, dump_sender_receiver, move_to, get_summary_writer, close
-from .early_stopping import BaseEarlyStopper, EarlyStopperAccuracy
+from .early_stopping import EarlyStopperAccuracy
 from .gs_wrappers import (GumbelSoftmaxWrapper,
                           SymbolGameGS, RelaxedEmbedding,
                           RnnSenderGS, RnnReceiverGS,
@@ -26,6 +26,7 @@ __all__ = [
     'init',
     'build_optimizer',
     'Callback',
+    'EarlyStopperAccuracy',
     'ConsoleLogger',
     'TensorboardLogger',
     'TemperatureUpdater',

--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .trainers import Trainer
-from .callbacks import Callback, ConsoleLogger, TensorboardLogger
+from .callbacks import Callback, ConsoleLogger, TensorboardLogger, TemperatureUpdater, CheckpointSaver
 from .util import init, get_opts, build_optimizer, dump_sender_receiver, move_to, get_summary_writer, close
 from .early_stopping import BaseEarlyStopper, EarlyStopperAccuracy
 from .gs_wrappers import (GumbelSoftmaxWrapper,
@@ -28,6 +28,8 @@ __all__ = [
     'Callback',
     'ConsoleLogger',
     'TensorboardLogger',
+    'TemperatureUpdater',
+    'CheckpointSaver',
     'ReinforceWrapper',
     'GumbelSoftmaxWrapper',
     'SymbolGameGS',

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -4,7 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
-from typing import Dict, Any
+from typing import Dict, Any, Union,  NamedTuple
+import pathlib
+
+import torch
 
 from egg.core.util import get_summary_writer
 
@@ -83,3 +86,63 @@ class TensorboardLogger(Callback):
 
     def on_train_end(self):
         self.writer.close()
+
+
+class TemperatureUpdater(Callback):
+
+    def __init__(self, agent, decay=0.9, minimum=0.1, update_frequency=1):
+        self.agent = agent
+        assert hasattr(agent, 'temperature'), 'Agent must have a `temperature` attribute'
+        assert not isinstance(agent.temperature, torch.nn.Parameter), \
+            'When using TemperatureUpdater, `temperature` cannot be trainable'
+        self.decay = decay
+        self.minimum = minimum
+        self.update_frequency = update_frequency
+        self.epoch_counter = 0
+
+    def on_epoch_end(self, loss: float, logs: Dict[str, Any] = None):
+        if self.epoch_counter % self.update_frequency == 0:
+            self.agent.temperature = max(self.minimum, self.agent.temperature * self.decay)
+        self.epoch_counter += 1
+
+
+class Checkpoint(NamedTuple):
+    epoch: int
+    model_state_dict: Dict[str, Any]
+    optimizer_state_dict: Dict[str, Any]
+
+
+class CheckpointSaver(Callback):
+
+    def __init__(
+            self,
+            checkpoint_path: Union[str, pathlib.Path],
+            checkpoint_freq: int = 1,
+            prefix: str = ''
+    ):
+        self.checkpoint_path = pathlib.Path(checkpoint_path)
+        self.checkpoint_freq = checkpoint_freq
+        self.prefix = prefix
+        self.epoch_counter = 0
+
+    def on_epoch_end(self, loss: float, logs: Dict[str, Any] = None):
+        if self.checkpoint_freq > 0 and (self.epoch_counter % self.checkpoint_freq == 0):
+            filename = f'{self.prefix}_{self.epoch_counter}' if self.prefix else str(self.epoch_counter)
+            self.save_checkpoint(filename=filename)
+        self.epoch_counter += 1
+
+    def on_train_end(self):
+        self.save_checkpoint(filename=f'{self.prefix}_final' if self.prefix else 'final')
+
+    def save_checkpoint(self, filename: str):
+        """
+        Saves the game, agents, and optimizer states to the checkpointing path under `<number_of_epochs>.tar` name
+        """
+        self.checkpoint_path.mkdir(exist_ok=True)
+        path = self.checkpoint_path / f'{filename}.tar'
+        torch.save(self.get_checkpoint(), path)
+
+    def get_checkpoint(self):
+        return Checkpoint(epoch=self.epoch_counter,
+                          model_state_dict=self.trainer.game.state_dict(),
+                          optimizer_state_dict=self.trainer.optimizer.state_dict())

--- a/egg/core/gs_wrappers.py
+++ b/egg/core/gs_wrappers.py
@@ -39,14 +39,6 @@ class GumbelSoftmaxWrapper(nn.Module):
         else:
             return torch.zeros_like(logits).scatter_(-1, logits.argmax(dim=-1, keepdim=True), 1.0)
 
-    def update_temp(self, decay, minimum):
-        """
-        Implements multiplicative temperature decay. Typically, could be used with a callback from `core.Trainer`
-        :param decay: Multiplicative factor
-        :param minimum: The lower bound on the temperature value
-        """
-        self.temperature = max(minimum, self.temperature * decay)
-
 
 class SymbolGameGS(nn.Module):
     """
@@ -154,12 +146,6 @@ class RnnSenderGS(nn.Module):
     >>> output = agent(torch.ones((1, 10)))
     >>> output.size()  # batch size x max_len x vocab_size
     torch.Size([1, 3, 2])
-    >>> agent.update_temp(decay=0.9, minimum=0.0)
-    >>> agent.temperature
-    0.9
-    >>> agent.update_temp(decay=0.1, minimum=0.5)
-    >>> agent.temperature
-    0.5
     """
     def __init__(self, agent, vocab_size, emb_dim, n_hidden, max_len, temperature, cell='rnn', force_eos=False,
                  trainable_temperature=False):
@@ -234,9 +220,6 @@ class RnnSenderGS(nn.Module):
             sequence = torch.cat([sequence, eos], dim=1)
 
         return sequence
-
-    def update_temp(self, decay, minimum):
-        self.temperature = max(minimum, self.temperature * decay)
 
 
 class RnnReceiverGS(nn.Module):
@@ -376,4 +359,3 @@ class SenderReceiverRnnGS(nn.Module):
 
         rest['mean_length'] = expected_length.mean()
         return loss.mean(), rest
-

--- a/egg/zoo/channel/train.py
+++ b/egg/zoo/channel/train.py
@@ -161,14 +161,10 @@ def main(params):
                                            receiver_entropy_coeff=opts.receiver_entropy_coeff,
                                            length_cost=opts.length_cost)
 
-    callback = None
-
     optimizer = core.build_optimizer(game.parameters())
 
-    early_stopper = EarlyStopperAccuracy(opts.early_stopping_thr)
-
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=callback, early_stopping=early_stopper)
+                           validation_data=test_loader, callbacks=[EarlyStopperAccuracy(opts.early_stopping_thr)])
 
     trainer.train(n_epochs=opts.n_epochs)
     if opts.checkpoint_dir:

--- a/egg/zoo/language_bottleneck/guess_number/train.py
+++ b/egg/zoo/language_bottleneck/guess_number/train.py
@@ -120,11 +120,11 @@ def main(params):
     intervention = CallbackEvaluator(test_loader, device=device, is_gs=opts.mode == 'gs', loss=loss, var_length=False,
                                      input_intervention=True)
 
-    early_stopper = EarlyStopperAccuracy(opts.early_stopping_thr)
-
-    trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=intervention,
-                           early_stopping=early_stopper, callbacks=[core.ConsoleLogger(as_json=True)])
+    trainer = core.Trainer(
+        game=game, optimizer=optimizer,
+        train_data=train_loader,
+        validation_data=test_loader,
+        callbacks=[core.ConsoleLogger(as_json=True), EarlyStopperAccuracy(opts.early_stopping_thr), intervention])
 
     trainer.train(n_epochs=opts.n_epochs)
 

--- a/egg/zoo/language_bottleneck/mnist_adv/train.py
+++ b/egg/zoo/language_bottleneck/mnist_adv/train.py
@@ -72,12 +72,10 @@ def main(params):
 
     optimizer = core.build_optimizer(game.parameters())
 
-    early_stopper = EarlyStopperAccuracy(opts.early_stopping_thr)
-
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
                            validation_data=test_loader,
-                           early_stopping=early_stopper,
-                           callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=True)])
+                           callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=True),
+                                      EarlyStopperAccuracy(opts.early_stopping_thr)])
 
     trainer.train(n_epochs=opts.n_epochs)
     core.close()

--- a/egg/zoo/language_bottleneck/mnist_classification/train.py
+++ b/egg/zoo/language_bottleneck/mnist_classification/train.py
@@ -71,16 +71,16 @@ def main(params):
 
     optimizer = core.build_optimizer(game.parameters())
 
-    early_stopper = EarlyStopperAccuracy(opts.early_stopping_thr)
-
     intervention = CallbackEvaluator(test_loader, device=opts.device, loss=game.loss,
                                      is_gs=True,
                                      var_length=False,
                                      input_intervention=True)
 
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=intervention,
-                           early_stopping=early_stopper, callbacks=[core.ConsoleLogger(as_json=True)])
+                           validation_data=test_loader,
+                           callbacks=[core.ConsoleLogger(as_json=True),
+                                      EarlyStopperAccuracy(opts.early_stopping_thr),
+                                      intervention])
 
     trainer.train(n_epochs=opts.n_epochs)
     core.close()

--- a/egg/zoo/language_bottleneck/mnist_overfit/train.py
+++ b/egg/zoo/language_bottleneck/mnist_overfit/train.py
@@ -87,12 +87,10 @@ def main(params):
 
     optimizer = core.build_optimizer(game.parameters())
 
-    early_stopper = EarlyStopperAccuracy(opts.early_stopping_thr)
-
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
                            validation_data=test_loader,
-                           early_stopping=early_stopper,
-                           callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=True)]
+                           callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=True),
+                                      EarlyStopperAccuracy(opts.early_stopping_thr)]
                            )
 
     trainer.train(n_epochs=opts.n_epochs)

--- a/egg/zoo/mnist_autoenc/train.py
+++ b/egg/zoo/mnist_autoenc/train.py
@@ -80,14 +80,14 @@ def main(params):
     game = core.SymbolGameGS(sender, receiver, loss)
     # This callback would be called at the end of each epoch by the Trainer; it reduces the sampling
     # temperature used by the GS
-    callback = lambda _: sender.update_temp(0.75, 0.01)
+    temperature_updater = core.TemperatureUpdater(agent=sender, decay=0.75, minimum=0.01)
     # get an optimizer that is set up by common command line parameters,
     # defaults to Adam
     optimizer = core.build_optimizer(game.parameters())
 
     # initialize and launch the trainer
-    trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=callback)
+    trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader, validation_data=test_loader,
+                           callbacks=[temperature_updater])
     trainer.train(n_epochs=opts.n_epochs)
 
     core.close()

--- a/egg/zoo/objects_game/train.py
+++ b/egg/zoo/objects_game/train.py
@@ -168,7 +168,6 @@ if __name__ == "__main__":
                                     )
 
         game = core.SenderReceiverRnnGS(sender, receiver, loss)
-        callback = sender.update_temp(0.9, 0.1)
     else:
         raise NotImplementedError(f'Unknown training mode, {opts.mode}')
 
@@ -176,10 +175,11 @@ if __name__ == "__main__":
         {'params': game.sender.parameters(), 'lr': opts.sender_lr},
         {'params': game.receiver.parameters(), 'lr': opts.receiver_lr}
     ])
-
+    callbacks = [core.ConsoleLogger(as_json=True)]
+    if opts.mode.lower() == 'gs':
+        callbacks.append(core.TemperatureUpdater(agent=sender, decay=0.9, minimum=0.1))
     trainer = core.Trainer(game=game, optimizer=optimizer,
-                           train_data=train_data, validation_data=validation_data, epoch_callback=callback,
-                           callbacks=[core.ConsoleLogger(as_json=True)])
+                           train_data=train_data, validation_data=validation_data, callbacks=callbacks)
     trainer.train(n_epochs=opts.n_epochs)
 
     if opts.evaluate:

--- a/egg/zoo/signal_game/train.py
+++ b/egg/zoo/signal_game/train.py
@@ -24,8 +24,6 @@ def parse_arguments():
                         help='Use same concepts')
     parser.add_argument('--vocab_size', type=int, default=100,
                         help='Vocabulary size')
-    parser.add_argument('--batch_size', type=int, default=32,
-                        help='Batch size')
     parser.add_argument('--embedding_size', type=int, default=50,
                         help='embedding size')
     parser.add_argument('--hidden_size', type=int, default=20,
@@ -98,9 +96,11 @@ if __name__ == '__main__':
     optimizer = core.build_optimizer(game.parameters())
     callback = None
     if opts.mode == 'gs':
-        callback = lambda _: game.sender.update_temp(0.75, 0.1)
+        callbacks = [core.TemperatureUpdater(agent=game.sender, decay=0.9, minimum=0.1)]
+    else:
+        callbacks = None
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=validation_loader, epoch_callback=callback)
+                           validation_data=validation_loader, callbacks=callbacks)
 
     trainer.train(n_epochs=opts.n_epochs)
 

--- a/egg/zoo/simple_autoenc/train.py
+++ b/egg/zoo/simple_autoenc/train.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
 
         game = core.SenderReceiverRnnReinforce(sender, receiver, loss, sender_entropy_coeff=opts.sender_entropy_coeff,
                                            receiver_entropy_coeff=opts.receiver_entropy_coeff)
-        callback = None
+        callbacks = []
     elif opts.mode.lower() == 'gs':
         sender = core.RnnSenderGS(sender, opts.vocab_size, opts.sender_embedding, opts.sender_hidden,
                                   cell=opts.sender_cell, max_len=opts.max_len, temperature=opts.temperature,
@@ -93,7 +93,7 @@ if __name__ == "__main__":
                     opts.receiver_hidden, cell=opts.receiver_cell)
 
         game = core.SenderReceiverRnnGS(sender, receiver, loss)
-        callback = sender.update_temp(0.9, 0.1)
+        callbacks = [core.TemperatureUpdater(agent=sender, decay=0.9, minimum=0.1)]
     else:
         raise NotImplementedError(f'Unknown training mode, {opts.mode}')
 
@@ -103,8 +103,8 @@ if __name__ == "__main__":
     ])
 
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
-                           validation_data=test_loader, epoch_callback=callback,
-                           callbacks=[core.ConsoleLogger(as_json=True)])
+                           validation_data=test_loader,
+                           callbacks=callbacks + [core.ConsoleLogger(as_json=True)])
     trainer.train(n_epochs=opts.n_epochs)
 
     core.close()

--- a/tests/test_agent_wrappers.py
+++ b/tests/test_agent_wrappers.py
@@ -3,12 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
-from torch.nn import functional as F
-import sys
 
+import sys
 from pathlib import Path
 sys.path.insert(0, Path(__file__).parent.parent.resolve().as_posix())
+
+import torch
+from torch.nn import functional as F
+
 import egg.core as core
 
 BATCH_X = torch.eye(8)
@@ -137,5 +139,3 @@ def test_symbol_wrapper():
     output_gs = receiver(message_gs)
 
     assert output_rf.eq(output_gs).all().item() == 1
-
-

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,103 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import sys
+import shutil
+from pathlib import Path
+sys.path.insert(0, Path(__file__).parent.parent.resolve().as_posix())
+
+import torch
+from torch.nn import functional as F
+
+import egg.core as core
+
+
+BATCH_X = torch.eye(8)
+BATCH_Y = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1]).long()
+
+
+class Dataset:
+    def __iter__(self):
+        return iter([(BATCH_X, BATCH_Y)])
+
+
+class Receiver(torch.nn.Module):
+    def __init__(self):
+        super(Receiver, self).__init__()
+
+    def forward(self, x, _input):
+        return x
+
+
+class ToyAgent(torch.nn.Module):
+    def __init__(self):
+        super(ToyAgent, self).__init__()
+        self.fc1 = torch.nn.Linear(8, 2, bias=False)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        return F.log_softmax(x, dim=1)
+
+
+class MockGame(torch.nn.Module):
+    def __init__(self):
+        super(MockGame, self).__init__()
+        self.param = torch.nn.Parameter(torch.Tensor([0]))
+
+    def forward(self, *args, **kwargs):
+        return self.param, {'acc': 1}
+
+
+def test_temperature_updater_callback():
+    core.init()
+    sender = core.GumbelSoftmaxWrapper(ToyAgent(), temperature=1)
+    receiver = Receiver()
+    loss = lambda sender_input, message, receiver_input, receiver_output, labels: \
+        (F.cross_entropy(receiver_output, BATCH_Y), {})
+
+    game = core.SymbolGameGS(sender, receiver, loss)
+    optimizer = torch.optim.Adam(game.parameters())
+
+    data = Dataset()
+    trainer = core.Trainer(game, optimizer, train_data=data, validation_data=None,
+                           callbacks=[core.TemperatureUpdater(agent=sender, decay=0.9)])
+    trainer.train(1)
+    assert sender.temperature == 0.9
+
+
+def test_snapshoting():
+    CHECKPOINT_PATH = Path('./test_checkpoints')
+
+    core.init()
+    sender = core.GumbelSoftmaxWrapper(ToyAgent(), temperature=1)
+    receiver = Receiver()
+    loss = lambda sender_input, message, receiver_input, receiver_output, labels: \
+        (F.cross_entropy(receiver_output, BATCH_Y), {})
+
+    game = core.SymbolGameGS(sender, receiver, loss)
+    optimizer = torch.optim.Adam(game.parameters())
+
+    data = Dataset()
+    trainer = core.Trainer(game, optimizer, train_data=data, validation_data=None,
+                           callbacks=[core.CheckpointSaver(checkpoint_path=CHECKPOINT_PATH)])
+    trainer.train(2)
+    assert (CHECKPOINT_PATH / Path('0.tar')).exists() and (CHECKPOINT_PATH / Path('1.tar')).exists()
+    assert (CHECKPOINT_PATH / Path('final.tar')).exists()
+    del trainer
+    trainer = core.Trainer(game, optimizer, train_data=data)  # Re-instantiate trainer
+    trainer.load_from_latest(CHECKPOINT_PATH)
+    assert trainer.starting_epoch == 2
+    trainer.train(3)
+    shutil.rmtree(CHECKPOINT_PATH)  # Clean-up
+
+
+def test_early_stopping():
+    game, data = MockGame(), Dataset()
+    early_stopper = core.EarlyStopperAccuracy(threshold=0.9)
+    trainer = core.Trainer(game=game, optimizer=torch.optim.Adam(game.parameters()), train_data=data,
+                           validation_data=data, callbacks=[early_stopper])
+    trainer.train(1)
+    assert trainer.should_stop

--- a/tutorials/EGG walkthrough with a MNIST autoencoder.ipynb
+++ b/tutorials/EGG walkthrough with a MNIST autoencoder.ipynb
@@ -401,9 +401,10 @@
     "game = core.SymbolGameGS(sender, receiver, loss)\n",
     "optimizer = torch.optim.Adam(game.parameters())\n",
     "\n",
-    "callback = lambda _: sender.update_temp(decay=0.9, minimum=0.1)\n",
-    "trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,\n",
-    "                           validation_data=test_loader, epoch_callback=callback)"
+    "trainer = core.Trainer(\n",
+    "    game=game, optimizer=optimizer, train_data=train_loader,\n",
+    "    validation_data=test_loader, callbacks=[core.TemperatureUpdater(agent=sender, decay=0.9, minimum=0.1)]\n",
+    ")"
    ]
   },
   {
@@ -839,7 +840,7 @@
     "optimizer = torch.optim.Adam(game.parameters(), lr=1e-2) #  we can also use a manually set optimizer\n",
     "\n",
     "trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,\n",
-    "                           validation_data=test_loader, epoch_callback=None)"
+    "                           validation_data=test_loader)"
    ]
   },
   {
@@ -1220,8 +1221,7 @@
     "receiver_rnn = core.RnnReceiverGS(receiver, vocab_size, emb_size,\n",
     "                    hidden_size, cell=\"gru\")\n",
     "\n",
-    "game_rnn = core.SenderReceiverRnnGS(sender_rnn, receiver_rnn, loss)\n",
-    "callback = sender_rnn.update_temp(0.9, 0.1)"
+    "game_rnn = core.SenderReceiverRnnGS(sender_rnn, receiver_rnn, loss)"
    ]
   },
   {


### PR DESCRIPTION
This pull requests contains the following changes:
1. Move checkpointing, early stopping and temperature updating to the new callback API
2. Fix a bug in callbacks (metrics can now be passed as either floats or `torch.Tensor`s)
3. Add unit tests for new callbacks
4. Rewrite zoo examples to conform to the new callback API

PS. In [some zoo examples](https://github.com/facebookresearch/EGG/blob/f0c3a70c26cd1c23a24f853189ac0d40687f3478/egg/zoo/simple_autoenc/train.py#L96), GS temperature updating was used in a wrong way, taking no effect because a `None` (the return type of `update_temperature`) instead of the callable itself is passed to the trainer. With the now API I believe this mistake is harder to make.