### PR TITLE
Fix metric reporting in 1-symbol game

### DIFF
--- a/egg/core/gs_wrappers.py
+++ b/egg/core/gs_wrappers.py
@@ -83,6 +83,10 @@ class SymbolGameGS(nn.Module):
         receiver_output = self.receiver(message, receiver_input)
 
         loss, rest_info = self.loss(sender_input, message, receiver_input, receiver_output, labels)
+        for k, v in rest_info.items():
+            if hasattr(v, 'mean'):
+                rest_info[k] = v.mean().item()
+
         return loss.mean(), rest_info
 
 

--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -123,6 +123,10 @@ class SymbolGameReinforce(nn.Module):
 
         full_loss = policy_loss + entropy_loss + loss.mean()
 
+        for k, v in rest_info.items():
+            if hasattr(v, 'mean'):
+                rest_info[k] = v.mean().item()
+
         rest_info['baseline'] = self.mean_baseline
         rest_info['loss'] = loss.mean().item()
         rest_info['sender_entropy'] = sender_entropy.mean()


### PR DESCRIPTION
In case additional perf metrics, like 'acc', are returned as a vector of [batch_size] dimension, and later used for early stopping, the latter would crash.

This might happen when we use the same loss both for variable length and single-symbol messages.