### PR TITLE
fix for torch 1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.1.0
+torch>=1.1.0
 torchvision
 scipy
 numpy


### PR DESCRIPTION
default torchvision install is now 0.4 which requires torch 1.2
this is one way to avoid the clash! 