### PR TITLE
fix epoch count when loading a model from checkpoint

### DIFF
--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -181,7 +181,7 @@ class Trainer:
     def load(self, checkpoint: Checkpoint):
         self.game.load_state_dict(checkpoint.model_state_dict)
         self.optimizer.load_state_dict(checkpoint.optimizer_state_dict)
-        self.starting_epoch = checkpoint.epoch
+        self.start_epoch = checkpoint.epoch
 
     def load_from_checkpoint(self, path):
         """


### PR DESCRIPTION
Fix a typo in a variable name in trainers.py to properly recover a model from a checkpoint with the right epoch count