### PR TITLE
fix import statements style to adhere pep8

### DIFF
--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -3,17 +3,17 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections import defaultdict
 import math
+
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions import Categorical
-from collections import defaultdict
-import numpy as np
 
-
-from .transformer import TransformerEncoder, TransformerDecoder
 from .rnn import RnnEncoder
+from .transformer import TransformerEncoder, TransformerDecoder
 from .util import find_lengths
 
 

--- a/egg/core/rnn.py
+++ b/egg/core/rnn.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
+
 from .util import find_lengths
 
 

--- a/egg/core/transformer.py
+++ b/egg/core/transformer.py
@@ -3,9 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
 from typing import Optional
 
-import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/egg/core/util.py
+++ b/egg/core/util.py
@@ -3,15 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import argparse
+from collections import defaultdict
+import random
+import sys
 from typing import Union, Iterable, List, Optional, Any
 
-import sys
-import random
-import argparse
-import torch
 import numpy as np
+import torch
 
-from collections import defaultdict
 
 common_opts = None
 optimizer = None

--- a/egg/nest/nest.py
+++ b/egg/nest/nest.py
@@ -3,11 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pathlib
 import argparse
-import time
 import importlib
+import pathlib
+import time
+
 from egg.nest.common import sweep
+
 
 if __name__ == '__main__':
     from egg.nest.wrappers import SlurmWrapper
@@ -101,4 +103,3 @@ if __name__ == '__main__':
         for job in jobs:
             print(jobs)
             job._send_requeue_signal(timeout=False)
-

--- a/egg/nest/nest_local.py
+++ b/egg/nest/nest_local.py
@@ -3,14 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pathlib
 import argparse
-import time
-import importlib
 from concurrent.futures import ProcessPoolExecutor, wait
+import importlib
+import pathlib
+import time
 
 from egg.nest.common import sweep
 from egg.nest.wrappers import ConcurrentWrapper
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="nest_local: a simple grid-search tool for EGG")

--- a/egg/nest/wrappers.py
+++ b/egg/nest/wrappers.py
@@ -6,6 +6,7 @@
 import json
 import pathlib
 import sys
+
 import torch
 
 


### PR DESCRIPTION
Fixing import statements order as 

1. Standard library imports.
2. Related third party imports.
3. Local application/library specific imports.

Whenever possible I tried to sort each group alphabetically to help reading if something is being imported or not

see [here] (https://www.python.org/dev/peps/pep-0008/#imports)