### PR TITLE
fix callbacks

### DIFF
--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -14,8 +14,9 @@ from egg.core.util import get_summary_writer
 
 class Callback:
 
-    def on_train_begin(self, trainer_instance: 'Trainer'):
+    def on_train_begin(self, trainer_instance):
         self.trainer = trainer_instance
+        self.epoch_counter = self.trainer.start_epoch
 
     def on_train_end(self):
         pass
@@ -38,7 +39,6 @@ class ConsoleLogger(Callback):
     def __init__(self, print_train_loss=False, as_json=False):
         self.print_train_loss = print_train_loss
         self.as_json = as_json
-        self.epoch_counter = 0
 
     def on_test_end(self, loss: float, logs: Dict[str, Any] = None):
         if self.as_json:
@@ -133,13 +133,12 @@ class CheckpointSaver(Callback):
         self.checkpoint_path = pathlib.Path(checkpoint_path)
         self.checkpoint_freq = checkpoint_freq
         self.prefix = prefix
-        self.epoch_counter = 0
 
     def on_epoch_end(self, loss: float, logs: Dict[str, Any] = None):
+        self.epoch_counter += 1
         if self.checkpoint_freq > 0 and (self.epoch_counter % self.checkpoint_freq == 0):
             filename = f'{self.prefix}_{self.epoch_counter}' if self.prefix else str(self.epoch_counter)
             self.save_checkpoint(filename=filename)
-        self.epoch_counter += 1
 
     def on_train_end(self):
         self.save_checkpoint(filename=f'{self.prefix}_final' if self.prefix else 'final')

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -14,7 +14,7 @@ from egg.core.util import get_summary_writer
 
 class Callback:
 
-    def on_train_begin(self, trainer_instance):
+    def on_train_begin(self, trainer_instance: 'Trainer'):
         self.trainer = trainer_instance
         self.epoch_counter = self.trainer.start_epoch
 

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -13,7 +13,6 @@ from egg.core.util import get_summary_writer
 
 
 class Callback:
-    trainer: 'Trainer'
 
     def on_train_begin(self, trainer_instance: 'Trainer'):
         self.trainer = trainer_instance

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -145,7 +145,7 @@ class Trainer:
             optimized_loss, rest = self.game(*batch)
             mean_rest = _add_dicts(mean_rest, rest)
             optimized_loss.backward()
-            
+
             if self.grad_norm:
                 torch.nn.utils.clip_grad_norm_(self.game.parameters(), self.grad_norm)
 


### PR DESCRIPTION
fixing minor bugs in callbacks logics:

1. early_stopper, even if it can store training stats, does not check them as a stopping criterion: I added a validation parameter to BaseEarlyStopper so that child classes can change that
2. fix epoch counter when logging stats and when saving a model (both after loading one and when training from scratch)