### PR TITLE
Factorising REINFORCE baselines out from Game; adding built-in baseline

### DIFF
--- a/egg/core/baselines.py
+++ b/egg/core/baselines.py
@@ -65,8 +65,9 @@ class MeanBaseline(Baseline):
 
 
 class BuiltInBaseline(Baseline):
-    """Built-in baseline; for any row in the batch, all other rows serve as control variates.
-    Assumes that rows in the batch are independent; most likely works poor for small batch sizes.
+    """Built-in baseline; for any row in the batch, the mean of all other rows serves as a control variate.
+    To use BuiltInBaseline, rows in the batch must be independent. Most likely BuiltInBaseline 
+    would work poorly for small batch sizes.
     """
 
     def __init__(self):

--- a/egg/core/baselines.py
+++ b/egg/core/baselines.py
@@ -1,0 +1,88 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import abstractmethod, ABC
+from collections import defaultdict
+
+import torch
+
+
+class Baseline(ABC, torch.nn.Module):
+    @abstractmethod
+    def update(self, loss: torch.Tensor) -> None:
+        """Update internal state according to the observed loss
+            loss (torch.Tensor): batch of losses
+        """
+        pass
+
+    @abstractmethod
+    def predict(self, loss: torch.Tensor) -> torch.Tensor:
+        """Return baseline for the loss
+        Args:
+            loss (torch.Tensor): batch of losses be baselined
+        """
+        pass
+
+
+class NoBaseline(Baseline):
+    """Baseline that does nothing (constant zero baseline)"""
+
+    def __init__(self):
+        super().__init__()
+
+    def update(self, loss: torch.Tensor) -> None:
+        pass
+
+    def predict(self, loss: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(1, device=loss.device)
+
+
+class MeanBaseline(Baseline):
+    """Running mean baseline; all loss batches have equal importance/weight,
+    hence it is better if they are equally-sized.
+    """"
+
+    def __init__(self):
+        super().__init__()
+
+        self.mean_baseline = torch.zeros(1, requires_grad=False)
+        self.n_points = 0.0
+
+    def update(self, loss: torch.Tensor) -> None:
+        self.n_points += 1
+        if self.mean_baseline.device != loss.device:
+            self.mean_baseline = self.mean_baseline.to(loss.device)
+
+        self.mean_baseline += (loss.detach().mean().item() -
+                               self.mean_baseline) / self.n_points
+
+    def predict(self, loss: torch.Tensor) -> torch.Tensor:
+        if self.mean_baseline.device != loss.device:
+            self.mean_baseline = self.mean_baseline.to(loss.device)
+        return self.mean_baseline
+
+
+class BuiltInBaseline(Baseline):
+    """Built-in baseline; for any row in the batch, all other rows serve as control variates.
+    Assumes that rows in the batch are independent; most likely works poor for small batch sizes.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def update(self, _: torch.Tensor) -> None:
+        pass
+
+    def predict(self, loss: torch.Tensor) -> torch.Tensor:
+        if len(loss.size()) == 0 or loss.size(0) <= 1:
+            return loss
+        bsz = loss.size(0)
+
+        loss_detached = loss.detach()
+        mean = loss_detached.mean()
+
+        baseline = (mean * bsz - loss_detached) / (bsz - 1.0)
+
+        return baseline

--- a/egg/core/baselines.py
+++ b/egg/core/baselines.py
@@ -42,7 +42,7 @@ class NoBaseline(Baseline):
 class MeanBaseline(Baseline):
     """Running mean baseline; all loss batches have equal importance/weight,
     hence it is better if they are equally-sized.
-    """"
+    """
 
     def __init__(self):
         super().__init__()

--- a/egg/core/baselines.py
+++ b/egg/core/baselines.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 import torch
 
 
-class Baseline(ABC, torch.nn.Module):
+class Baseline(ABC):
     @abstractmethod
     def update(self, loss: torch.Tensor) -> None:
         """Update internal state according to the observed loss

--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -15,7 +15,7 @@ from torch.distributions import Categorical
 from .rnn import RnnEncoder
 from .transformer import TransformerEncoder, TransformerDecoder
 from .util import find_lengths
-from .baselines import NoBaseline, MeanBaseline, BuiltInBaseline
+from .baselines import MeanBaseline
 
 
 class ReinforceWrapper(nn.Module):
@@ -341,7 +341,7 @@ class SenderReceiverRnnReinforce(nn.Module):
     5.0
     """
     def __init__(self, sender, receiver, loss, sender_entropy_coeff, receiver_entropy_coeff,
-                 length_cost=0.0):
+                 length_cost=0.0, baseline_type=MeanBaseline):
         """
         :param sender: sender agent
         :param receiver: receiver agent
@@ -367,8 +367,7 @@ class SenderReceiverRnnReinforce(nn.Module):
         self.loss = loss
         self.length_cost = length_cost
 
-        self.mean_baseline = defaultdict(float)
-        self.n_points = defaultdict(float)
+        self.baselines = defaultdict(baseline_type)
 
     def forward(self, sender_input, labels, receiver_input=None):
         message, log_prob_s, entropy_s = self.sender(sender_input)
@@ -397,16 +396,16 @@ class SenderReceiverRnnReinforce(nn.Module):
 
         length_loss = message_lengths.float() * self.length_cost
 
-        policy_length_loss = ((length_loss.float() - self.mean_baseline['length']) * effective_log_prob_s).mean()
-        policy_loss = ((loss.detach() - self.mean_baseline['loss']) * log_prob).mean()
+        policy_length_loss = ((length_loss - self.baselines['length'].predict(length_loss)) * effective_log_prob_s).mean()
+        policy_loss = ((loss.detach() - self.baselines['loss'].predict(loss.detach())) * log_prob).mean()
 
         optimized_loss = policy_length_loss + policy_loss - weighted_entropy
         # if the receiver is deterministic/differentiable, we apply the actual loss
         optimized_loss += loss.mean()
 
         if self.training:
-            self.update_baseline('loss', loss)
-            self.update_baseline('length', length_loss)
+            self.baselines['loss'].update(loss)
+            self.baselines['length'].update(length_loss)
 
         for k, v in rest.items():
             rest[k] = v.mean().item() if hasattr(v, 'mean') else v
@@ -417,10 +416,6 @@ class SenderReceiverRnnReinforce(nn.Module):
         rest['mean_length'] = message_lengths.float().mean().item()
 
         return optimized_loss, rest
-
-    def update_baseline(self, name, value):
-        self.n_points[name] += 1
-        self.mean_baseline[name] += (value.detach().mean().item() - self.mean_baseline[name]) / self.n_points[name]
 
 
 class TransformerReceiverDeterministic(nn.Module):

--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -97,7 +97,7 @@ class SymbolGameReinforce(nn.Module):
           and outputs the end-to-end loss. Can be non-differentiable; if it is differentiable, this will be leveraged
         :param sender_entropy_coeff: The entropy regularization coefficient for Sender
         :param receiver_entropy_coeff: The entropy regularizatino coefficient for Receiver
-        :param baseline_type:
+        :param baseline_type: Callable, returns a baseline instance (eg a class specializing core.baselines.Baseline)
         """
         super(SymbolGameReinforce, self).__init__()
         self.sender = sender
@@ -358,6 +358,7 @@ class SenderReceiverRnnReinforce(nn.Module):
         :param sender_entropy_coeff: entropy regularization coeff for sender
         :param receiver_entropy_coeff: entropy regularization coeff for receiver
         :param length_cost: the penalty applied to Sender for each symbol produced
+        :param baseline_type: Callable, returns a baseline instance (eg a class specializing core.baselines.Baseline)
         """
         super(SenderReceiverRnnReinforce, self).__init__()
         self.sender = sender

--- a/egg/zoo/compo_vs_generalization/train.py
+++ b/egg/zoo/compo_vs_generalization/train.py
@@ -186,11 +186,10 @@ def main(params):
         game=game, optimizer=optimizer,
         train_data=train_loader,
         validation_data=validation_loader,
-        callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=True),
+        callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=False),
                    early_stopper,
                    metrics_evaluator,
-                   holdout_evaluator
-                   ])
+                   holdout_evaluator])
     trainer.train(n_epochs=opts.n_epochs)
 
     validation_acc = early_stopper.validation_stats[-1][1]['acc']

--- a/egg/zoo/compo_vs_generalization/train.py
+++ b/egg/zoo/compo_vs_generalization/train.py
@@ -187,13 +187,12 @@ def main(params):
         train_data=train_loader,
         validation_data=validation_loader,
         callbacks=[core.ConsoleLogger(as_json=True, print_train_loss=True),
-                   #early_stopper,
-                   #metrics_evaluator,
-                   #holdout_evaluator
+                   early_stopper,
+                   metrics_evaluator,
+                   holdout_evaluator
                    ])
     trainer.train(n_epochs=opts.n_epochs)
 
-    exit(0)
     validation_acc = early_stopper.validation_stats[-1][1]['acc']
     uniformtest_acc = holdout_evaluator.results['uniform holdout']['acc']
 


### PR DESCRIPTION
The old baseline remains default, so no changes in any of the existing games (hopefully :) though I did check that) 

- Built-in baseline comes from here https://arxiv.org/pdf/2002.06043.pdf and https://arxiv.org/abs/1602.06725
- Works as follows: takes a batch of rewards; for each row, the mean of all other rows is a baseline;
- Assumes that rewards in the batch must be independent
- Larger batches are probably better (ie doesn't do anything for the batch of size 1, is very noisy for the batch size of 2, ...)

Comparison on `egg.zoo.compo_vs_generalization.train` with hyper-parameters
```json
{
    "n_attributes": [2],
    "n_values": [16],
    "vocab_size" : [50],
    "max_len" : [6],
    "batch_size" : [5120],
    "data_scaler": [60],
    "n_epochs": [500],
    "random_seed": [0,1,2,3,4],
    "sender_hidden": [500],
    "receiver_hidden": [500],
    "sender_entropy_coeff": [0.5],
    "sender_cell": ["gru"],
    "receiver_cell": ["gru"],
    "lr":[0.001],
    "receiver_emb": [30],
    "sender_emb": [5],
    "baseline": ["no", "mean", "builtin"]
}
```

results in:
![image](https://user-images.githubusercontent.com/22791636/85045724-a848bb80-b18f-11ea-9462-a0be8874090a.png)
![image](https://user-images.githubusercontent.com/22791636/85045737-ae3e9c80-b18f-11ea-9269-8816a6778838.png)
