### PR TITLE
Persisting interactions

### DIFF
--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -5,7 +5,7 @@
 
 from .trainers import Trainer
 from .callbacks import Callback, ConsoleLogger, TensorboardLogger, TemperatureUpdater, CheckpointSaver
-from .util import init, get_opts, build_optimizer, dump_sender_receiver, move_to, get_summary_writer, close
+from .util import init, get_opts, build_optimizer, dump_interactions, move_to, get_summary_writer, close
 from .early_stopping import EarlyStopperAccuracy
 from .gs_wrappers import (GumbelSoftmaxWrapper,
                           SymbolGameGS, RelaxedEmbedding,
@@ -44,7 +44,7 @@ __all__ = [
     'RnnSenderGS',
     'RnnReceiverGS',
     'SenderReceiverRnnGS',
-    'dump_sender_receiver',
+    'dump_interactions',
     'move_to',
     'get_summary_writer',
     'close',

--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -19,6 +19,7 @@ from .reinforce_wrappers import (ReinforceWrapper, SymbolGameReinforce,
                                  TransformerSenderReinforce)
 from .util import find_lengths
 from .rnn import RnnEncoder
+from .interaction import LoggingStrategy, Interaction
 
 __all__ = [
     'Trainer',
@@ -52,5 +53,7 @@ __all__ = [
     'TransformerReceiverDeterministic',
     'TransformerSenderReinforce',
     'RnnEncoder',
-    'find_lengths'
+    'find_lengths',
+    'LoggingStrategy',
+    'Interaction'
 ]

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -50,11 +50,10 @@ class ConsoleLogger(Callback):
     @staticmethod
     def aggregate_interactions(interactions: List[Interaction]) -> Dict[str, float]:
         aggregated = defaultdict(float)
-        normalizer = 0
+        normalizer = 0.0
 
         for interaction in interactions:
-            bsz = interaction.sender_input.size(0)
-            normalizer += bsz
+            normalizer += interaction.bsz
 
             aggregated['message_length'] += interaction.message_length.sum()
 

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -42,7 +42,7 @@ class ConsoleLogger(Callback):
         self.as_json = as_json
 
     def aggregate_print(self, loss: float, logs: Interaction, mode: str):
-        dump = dict(loss=_to_number(loss, 'mean'))
+        dump = dict(loss=loss.mean())
         aggregated_metrics = dict((k, v.mean().item()) for k, v in logs.aux.items())
         dump.update(aggregated_metrics)
 
@@ -62,16 +62,6 @@ class ConsoleLogger(Callback):
 
         if not self.print_train_loss: return
         self.aggregate_print(loss, logs, 'train')
-
-def _to_number(metric: Union[torch.Tensor, float], aggregation: str) -> float:
-    if torch.is_tensor(metric) and aggregation == 'mean':
-        return metric.float().mean().item()
-    elif torch.is_tensor(metric) and aggregation == 'sum':
-        return metric.float().sum().item()
-    elif type(metric) == float:
-        return metric
-    else:
-        raise TypeError('Metric must be either float or torch.Tensor')
 
 
 class TensorboardLogger(Callback):

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -19,13 +19,6 @@ def _div_dict(d, n):
     return result
 
 
-#def _add_dicts(a, b):
-#    result = dict(a)
-#    for k, v in b.items():
-#        result[k] = result.get(k, 0) + v
-#    return result
-
-
 class Callback:
 
     def on_train_begin(self, trainer_instance: 'Trainer'):

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -3,12 +3,20 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Any, Union,  NamedTuple, List
+from collections import defaultdict
 import json
 import pathlib
-from collections import defaultdict
+from typing import Dict, Any, Union,  NamedTuple, List
 
+try:
+    import editdistance  # package to install https://pypi.org/project/editdistance/0.3.1/
+except ImportError:
+    print('Please install editdistance package: `pip install editdistance`. '
+          'It is used for calculating topographic similarity.')
+from scipy.spatial import distance
+from scipy.stats import spearmanr
 import torch
+
 from egg.core.util import get_summary_writer
 from .interaction import Interaction
 
@@ -145,3 +153,50 @@ class CheckpointSaver(Callback):
         return Checkpoint(epoch=self.epoch_counter,
                           model_state_dict=self.trainer.game.state_dict(),
                           optimizer_state_dict=self.trainer.optimizer.state_dict())
+
+
+class TopographicSimilarity(Callback):
+    distances = {'edit': lambda x, y: editdistance.eval(x, y) / (len(x) + len(y)) / 2,
+                 'cosine': distance.cosine,
+                 'hamming':distance.hamming,
+                 'jaccard': distance.jaccard,
+                 'euclidean': distance.euclidean,
+                 }
+
+    def __init__(self,
+                 sender_input_distance_fn='cosine',
+                 message_distance_fn='edit',
+                 compute_topsim_train_set=False,
+                 compute_topsim_test_set=True):
+
+        self.sender_input_distance_fn = self.distances.get(sender_input_distance_fn, None)
+        self.message_distance_fn = self.distances.get(message_distance_fn, None)
+        self.compute_topsim_train_set = compute_topsim_train_set
+        self.compute_topsim_test_set = compute_topsim_test_set
+
+        assert self.sender_input_distance_fn and self.message_distance_fn, f"Cannot recognize {sender_input_distance_fn} or {message_distance_fn} distances"
+        assert compute_topsim_train_set or compute_topsim_test_set
+
+    def on_test_end(self, loss: float, logs: Interaction):
+        if self.compute_topsim_test_set:
+            self.compute_similarity(sender_input=logs.sender_input, messages=logs.message)
+
+    def on_epoch_end(self, loss: float, logs: Interaction):
+        if self.compute_topsim_train_set:
+            self.compute_similarity(sender_input=logs.sender_input, messages=logs.message)
+
+    def compute_similarity(self, sender_input, messages):
+        def compute_distance(_list, distance):
+            return [distance(el1, el2)
+                        for i, el1 in enumerate(_list[:-1])
+                        for j, el2 in enumerate(_list[i+1:])
+                    ]
+
+        messages = [msg.tolist() for msg in messages]
+
+        input_dist = compute_distance(sender_input.numpy(), self.sender_input_distance_fn)
+        message_dist = compute_distance(messages, self.message_distance_fn)
+        topsim = spearmanr(input_dist, message_dist, nan_policy='raise').correlation
+
+        output_message = json.dumps(dict(topsim=topsim))
+        print(output_message, flush=True)

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -6,7 +6,7 @@
 from collections import defaultdict
 import json
 import pathlib
-from typing import Dict, Any, Union,  NamedTuple, List
+from typing import Dict, Any, Union,  NamedTuple, List, Callable
 
 try:
     import editdistance  # package to install https://pypi.org/project/editdistance/0.3.1/
@@ -164,13 +164,15 @@ class TopographicSimilarity(Callback):
                  }
 
     def __init__(self,
-                 sender_input_distance_fn='cosine',
-                 message_distance_fn='edit',
-                 compute_topsim_train_set=False,
-                 compute_topsim_test_set=True):
+                 sender_input_distance_fn: Union[str, Callable] = 'cosine',
+                 message_distance_fn: Union[str, Callable] = 'edit',
+                 compute_topsim_train_set: bool = False,
+                 compute_topsim_test_set: bool = True):
 
-        self.sender_input_distance_fn = self.distances.get(sender_input_distance_fn, None)
-        self.message_distance_fn = self.distances.get(message_distance_fn, None)
+        self.sender_input_distance_fn = self.distances.get(sender_input_distance_fn, None) \
+            if isinstance(sender_input_distance_fn, str) else sender_input_distance_fn
+        self.message_distance_fn = self.distances.get(message_distance_fn, None) \
+            if isinstance(message_distance_fn, str) else message_distance_fn
         self.compute_topsim_train_set = compute_topsim_train_set
         self.compute_topsim_test_set = compute_topsim_test_set
 
@@ -185,7 +187,7 @@ class TopographicSimilarity(Callback):
         if self.compute_topsim_train_set:
             self.compute_similarity(sender_input=logs.sender_input, messages=logs.message)
 
-    def compute_similarity(self, sender_input, messages):
+    def compute_similarity(self, sender_input: torch.Tensor, messages: torch.Tensor):
         def compute_distance(_list, distance):
             return [distance(el1, el2)
                         for i, el1 in enumerate(_list[:-1])

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -12,12 +12,6 @@ import torch
 from egg.core.util import get_summary_writer
 from .interaction import Interaction
 
-def _div_dict(d, n):
-    result = dict(d)
-    for k in result:
-        result[k] /= n
-    return result
-
 
 class Callback:
 

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -42,7 +42,7 @@ class ConsoleLogger(Callback):
         self.as_json = as_json
 
     def aggregate_print(self, loss: float, logs: Interaction, mode: str):
-        dump = dict(loss=loss.mean())
+        dump = dict(loss=loss) 
         aggregated_metrics = dict((k, v.mean().item()) for k, v in logs.aux.items())
         dump.update(aggregated_metrics)
 

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -73,15 +73,15 @@ class TensorboardLogger(Callback):
             self.writer = get_summary_writer()
         self.epoch_counter = 0
 
-    def on_test_end(self, loss: float, logs: Dict[str, Any] = None):
+    def on_test_end(self, loss: float, logs: Interaction):
         self.writer.add_scalar(tag=f'test/loss', scalar_value=loss, global_step=self.epoch_counter)
-        for k, v in logs.items():
-            self.writer.add_scalar(tag=f'test/{k}', scalar_value=v, global_step=self.epoch_counter)
+        for k, v in logs.aux.items():
+            self.writer.add_scalar(tag=f'test/{k}', scalar_value=v.mean(), global_step=self.epoch_counter)
 
-    def on_epoch_end(self, loss: float, logs: Dict[str, Any] = None):
+    def on_epoch_end(self, loss: float, logs: Interaction):
         self.writer.add_scalar(tag=f'train/loss', scalar_value=loss, global_step=self.epoch_counter)
-        for k, v in logs.items():
-            self.writer.add_scalar(tag=f'train/{k}', scalar_value=v, global_step=self.epoch_counter)
+        for k, v in logs.aux.items():
+            self.writer.add_scalar(tag=f'train/{k}', scalar_value=v.mean(), global_step=self.epoch_counter)
         self.epoch_counter += 1
 
     def on_train_end(self):

--- a/egg/core/early_stopping.py
+++ b/egg/core/early_stopping.py
@@ -15,8 +15,8 @@ class BaseEarlyStopper(Callback):
     """
     def __init__(self, validation: bool = True):
         super(BaseEarlyStopper, self).__init__()
-        self.train_stats: List[Tuple[float, Dict[str, Any]]] = []
-        self.validation_stats: List[Tuple[float, Dict[str, Any]]] = []
+        self.train_stats: List[Tuple[float, Interaction]] = []
+        self.validation_stats: List[Tuple[float, Interaction]] = []
         self.epoch: int = 0
         self.validation = validation
 

--- a/egg/core/early_stopping.py
+++ b/egg/core/early_stopping.py
@@ -63,6 +63,6 @@ class EarlyStopperAccuracy(BaseEarlyStopper):
             loss, last_epoch_interactions = self.train_stats[-1]
 
         metric_sum = sum(x.aux[self.field_name].sum() for x in last_epoch_interactions)
-        normalizer = sum(x.aux[self.field_name].size(0) for x in last_epoch_interactions)
+        normalizer = sum(x.bsz for x in last_epoch_interactions)
 
         return metric_sum / normalizer >= self.threshold

--- a/egg/core/early_stopping.py
+++ b/egg/core/early_stopping.py
@@ -20,14 +20,14 @@ class BaseEarlyStopper(Callback):
         self.epoch: int = 0
         self.validation = validation
 
-    def on_epoch_end(self, loss: float, logs: List[Interaction]) -> None:
+    def on_epoch_end(self, loss: float, logs: Interaction) -> None:
         if self.validation:
             return
         self.epoch += 1
         self.train_stats.append((loss, logs))
         self.trainer.should_stop = self.should_stop()
 
-    def on_test_end(self, loss: float, logs: List[Interaction]) -> None:
+    def on_test_end(self, loss: float, logs: Interaction) -> None:
         if not self.validation:
             return
         self.validation_stats.append((loss, logs))
@@ -62,7 +62,6 @@ class EarlyStopperAccuracy(BaseEarlyStopper):
             assert self.train_stats, 'Training data must be provided for early stooping to work'
             loss, last_epoch_interactions = self.train_stats[-1]
 
-        metric_sum = sum(x.aux[self.field_name].sum() for x in last_epoch_interactions)
-        normalizer = sum(x.bsz for x in last_epoch_interactions)
+        metric_mean = last_epoch_interactions.aux[self.field_name].mean()
 
-        return metric_sum / normalizer >= self.threshold
+        return metric_mean >= self.threshold

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -1,0 +1,37 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree
+
+from typing import Optional, Dict, Union
+from dataclasses import dataclass
+import torch
+
+@dataclass
+class Interaction:
+    # incoming data
+    sender_input: torch.Tensor
+    receiver_input: Optional[torch.Tensor]
+    labels: Optional[torch.Tensor]
+
+    # what agents produce
+    message: torch.Tensor
+    receiver_output: torch.Tensor
+
+    # auxilary info
+    message_length: Optional[torch.Tensor]
+    aux: Dict[str, Union[float, int, torch.Tensor]]
+
+
+    @staticmethod
+    def from_batch(sender_input, receiver_input, labels):
+        interacton = Interaction(
+            sender_input,
+            receiver_input,
+            labels,
+            message=None,
+            receiver_output=None,
+            message_length=None,
+            aux={}
+        )
+

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -45,8 +45,8 @@ class Interaction:
     labels: Optional[torch.Tensor]
 
     # what agents produce
-    message: torch.Tensor
-    receiver_output: torch.Tensor
+    message: Optional[torch.Tensor]
+    receiver_output: Optional[torch.Tensor]
 
     # auxilary info
     message_length: Optional[torch.Tensor]
@@ -54,11 +54,9 @@ class Interaction:
 
     @cached_property
     def bsz(self):
-        something_stored = self.sender_input or self.receiver_input or self.labels or self.message or \
-             self.receiver_output or self.message_length or None
-        if something_stored is None:
-            raise RuntimeError('Cannot determine interaction log size; it is empty.')
-        return something_stored.size(0)
+        for t in [self.sender_input, self.receiver_input, self.labels, self.message, self.receiver_output, self.message_length]:
+            if t is not None: return t.size(0)
+        raise RuntimeError('Cannot determine interaction log size; it is empty.')
 
     def to(self, *args, **kwargs) -> 'Interaction':
         """Moves all stored tensor to a device. For instance, it might be not

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -5,6 +5,7 @@
 
 from typing import Optional, Dict, Union
 from dataclasses import dataclass
+from functools import cached_property
 import torch
 
 @dataclass
@@ -22,16 +23,6 @@ class Interaction:
     message_length: Optional[torch.Tensor]
     aux: Dict[str, Union[float, int, torch.Tensor]]
 
-
-    @staticmethod
-    def from_batch(sender_input, receiver_input, labels):
-        interacton = Interaction(
-            sender_input,
-            receiver_input,
-            labels,
-            message=None,
-            receiver_output=None,
-            message_length=None,
-            aux={}
-        )
-
+    @cached_property
+    def bsz(self):
+        return self.sender_input.size(0)

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -21,8 +21,64 @@ class Interaction:
 
     # auxilary info
     message_length: Optional[torch.Tensor]
-    aux: Dict[str, Union[float, int, torch.Tensor]]
+    aux: Dict[str, torch.Tensor]
 
     @cached_property
     def bsz(self):
         return self.sender_input.size(0)
+
+    def to(self, *args, **kwargs):
+        """Moves all stored tensor to a device. For instance, it might be not
+        useful to store the interaction logs in CUDA memory."""
+        def _to(x):
+            if x is None or not torch.is_tensor(x): return x
+            return x.to(*args, **kwargs)
+
+        self.sender_input = _to(self.sender_input)
+        self.receiver_input = _to(self.receiver_input)
+        self.labels = _to(self.labels)
+        self.message = _to(self.message)
+        self.receiver_output = _to(self.receiver_output)
+        self.message_length = _to(self.message_length)
+
+        if self.aux:
+            self.aux = dict((k, _to(v)) for k, v in self.aux.items())
+
+    def __add__(self, other: 'Interaction') -> 'Interaction':
+        """
+        >>> a = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
+        >>> a.bsz
+        1
+        >>> b = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
+        >>> c = a + b
+        >>> c.bsz
+        2
+        >>> c
+        Interaction(sender_input=tensor([1., 1.]), receiver_input=None, labels=None, message=tensor([1., 1.]), receiver_output=tensor([1., 1.]), message_length=None, aux={})
+        >>> d = Interaction(torch.ones(1), torch.ones(1), None, torch.ones(1), torch.ones(1), None, {})
+        >>> a + d # mishaped, should throw an exception
+        Traceback (most recent call last):
+        ...
+        RuntimeError: Appending empty and non-empty interactions logs. Normally this shouldn't happen!
+        """
+        def _check_append(a, b):
+            if a is None and b is None: return None
+            if a is not None and b is not None:
+                return torch.cat((a, b), dim=0)
+            raise RuntimeError("Appending empty and non-empty interactions logs. "
+                               "Normally this shouldn't happen!")
+
+        aux = {}
+        for k in self.aux:
+            assert k in other.aux
+            aux[k] = _check_append(self.aux[k], other.aux[k])
+
+        return Interaction(
+            sender_input=_check_append(self.sender_input, other.sender_input),
+            receiver_input=_check_append(self.receiver_input, other.receiver_input),
+            labels=_check_append(self.labels, other.labels),
+            message=_check_append(self.message, other.message),
+            message_length=_check_append(self.message_length, other.message_length),
+            receiver_output=_check_append(self.receiver_output, other.receiver_output),
+            aux=aux
+        )

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -52,7 +52,7 @@ class Interaction:
     aux: Dict[str, torch.Tensor]
 
     @cached_property
-    def bsz(self):
+    def size(self):
         for t in [self.sender_input, self.receiver_input, self.labels, self.message, self.receiver_output, self.message_length]:
             if t is not None: return t.size(0)
         raise RuntimeError('Cannot determine interaction log size; it is empty.')
@@ -80,11 +80,11 @@ class Interaction:
     def from_iterable(interactions: Iterable['Interaction']) -> 'Interaction':
         """
         >>> a = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
-        >>> a.bsz
+        >>> a.size
         1
         >>> b = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
         >>> c = Interaction.from_iterable((a, b))
-        >>> c.bsz
+        >>> c.size
         2
         >>> c
         Interaction(sender_input=tensor([1., 1.]), receiver_input=None, labels=None, message=tensor([1., 1.]), receiver_output=tensor([1., 1.]), message_length=None, aux={})

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -78,6 +78,22 @@ class Interaction:
 
     @staticmethod
     def from_iterable(interactions: Iterable['Interaction']) -> 'Interaction':
+        """
+        >>> a = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
+        >>> a.bsz
+        1
+        >>> b = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
+        >>> c = Interaction.from_iterable((a, b))
+        >>> c.bsz
+        2
+        >>> c
+        Interaction(sender_input=tensor([1., 1.]), receiver_input=None, labels=None, message=tensor([1., 1.]), receiver_output=tensor([1., 1.]), message_length=None, aux={})
+        >>> d = Interaction(torch.ones(1), torch.ones(1), None, torch.ones(1), torch.ones(1), None, {})
+        >>> _ = Interaction.from_iterable((a, d)) # mishaped, should throw an exception
+        Traceback (most recent call last):
+        ...
+        RuntimeError: Appending empty and non-empty interactions logs. Normally this shouldn't happen!
+        """
         def _check_cat(lst):
             if all(x is None for x in lst):
                 return None
@@ -103,27 +119,6 @@ class Interaction:
             message_length=_check_cat([x.message_length for x in interactions]),
             receiver_output=_check_cat([x.receiver_output for x in interactions]),
             aux=aux)
-
-
-    def __add__(self, other: 'Interaction') -> 'Interaction':
-        """
-        >>> a = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
-        >>> a.bsz
-        1
-        >>> b = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
-        >>> c = a + b
-        >>> c.bsz
-        2
-        >>> c
-        Interaction(sender_input=tensor([1., 1.]), receiver_input=None, labels=None, message=tensor([1., 1.]), receiver_output=tensor([1., 1.]), message_length=None, aux={})
-        >>> d = Interaction(torch.ones(1), torch.ones(1), None, torch.ones(1), torch.ones(1), None, {})
-        >>> a + d # mishaped, should throw an exception
-        Traceback (most recent call last):
-        ...
-        RuntimeError: Appending empty and non-empty interactions logs. Normally this shouldn't happen!
-        """
-        return Interaction.from_iterable((self, other))
-
 
     @staticmethod
     def empty() -> 'Interaction':

--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -329,16 +329,15 @@ class SenderReceiverRnnReinforce(nn.Module):
     ...         return self.fc(rnn_output)
     >>> receiver = RnnReceiverDeterministic(Receiver(), vocab_size=15, embed_dim=10, hidden_size=5)
     >>> def loss(sender_input, _message, _receiver_input, receiver_output, _labels):
-    ...     return F.mse_loss(sender_input, receiver_output, reduction='none').mean(dim=1), {'aux': 5.0}
-
+    ...     return F.mse_loss(sender_input, receiver_output, reduction='none').mean(dim=1), {'aux': torch.ones(sender_input.size(0))}
     >>> game = SenderReceiverRnnReinforce(sender, receiver, loss, sender_entropy_coeff=0.0, receiver_entropy_coeff=0.0,
     ...                                   length_cost=1e-2)
-    >>> input = torch.zeros((16, 3)).normal_()
-    >>> optimized_loss, aux_info = game(input, labels=None)
-    >>> sorted(list(aux_info.keys()))  # returns some debug info, such as entropies of the agents, message length etc
-    ['aux', 'loss', 'mean_length', 'original_loss', 'receiver_entropy', 'sender_entropy']
-    >>> aux_info['aux']
-    5.0
+    >>> input = torch.zeros((5, 3)).normal_()
+    >>> optimized_loss, interaction = game(input, labels=None)
+    >>> sorted(list(interaction.aux.keys()))  # returns some debug info, such as entropies of the agents, message length etc
+    ['aux', 'loss', 'original_loss', 'receiver_entropy', 'sender_entropy']
+    >>> interaction.aux['aux'], interaction.aux['aux'].sum()
+    (tensor([1., 1., 1., 1., 1.]), tensor(5.))
     """
     def __init__(self, sender, receiver, loss, sender_entropy_coeff, receiver_entropy_coeff,
                  length_cost=0.0, baseline_type=MeanBaseline):

--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -132,7 +132,7 @@ class SymbolGameReinforce(nn.Module):
         interaction = self.logging_strategy.filtered_interaction(sender_input=sender_input,
                                                                  labels=labels, receiver_input=receiver_input,
                                                                  message=message.detach(), receiver_output=receiver_output.detach(),
-                                                                 message_lengths=torch.ones(message.size(0)), aux=aux_info)
+                                                                 message_length=torch.ones(message.size(0)), aux=aux_info)
 
         return full_loss, interaction
 
@@ -338,7 +338,7 @@ class SenderReceiverRnnReinforce(nn.Module):
     >>> input = torch.zeros((5, 3)).normal_()
     >>> optimized_loss, interaction = game(input, labels=None)
     >>> sorted(list(interaction.aux.keys()))  # returns some debug info, such as entropies of the agents, message length etc
-    ['aux', 'loss', 'original_loss', 'receiver_entropy', 'sender_entropy']
+    ['aux', 'receiver_entropy', 'sender_entropy']
     >>> interaction.aux['aux'], interaction.aux['aux'].sum()
     (tensor([1., 1., 1., 1., 1.]), tensor(5.))
     """

--- a/egg/core/util.py
+++ b/egg/core/util.py
@@ -197,11 +197,11 @@ def dump_interactions(game: torch.nn.Module,
             interaction = interaction.to('cpu')
 
             if gs:
-                interaction.message = interactions.message.argmax(dim=-1)  # actual symbols instead of one-hot encoded
+                interaction.message = interaction.message.argmax(dim=-1)  # actual symbols instead of one-hot encoded
             if apply_padding and variable_length:
                 assert interaction.message_length is not None
-                for i in range(interactions.bsz):
-                    l = interaction.message_length[i]
+                for i in range(interaction.bsz):
+                    l = interaction.message_length[i].long().item()
                     interaction.message[i, l:] = 0 # 0 is always EOS
 
             full_interaction = full_interaction + interaction if full_interaction is not None else interaction

--- a/egg/core/util.py
+++ b/egg/core/util.py
@@ -11,7 +11,7 @@ from typing import Union, Iterable, List, Optional, Any
 
 import numpy as np
 import torch
-
+from .interaction import Interaction
 
 common_opts = None
 optimizer = None
@@ -169,80 +169,45 @@ def _set_seed(seed) -> None:
         torch.cuda.manual_seed_all(seed)
 
 
-def dump_sender_receiver(game: torch.nn.Module,
-                         dataset: 'torch.utils.data.DataLoader',
-                         gs: bool, variable_length: bool,
-                         device: Optional[torch.device] = None):
+def dump_interactions(game: torch.nn.Module,
+                      dataset: 'torch.utils.data.DataLoader',
+                      gs: bool,
+                      variable_length: bool,
+                      device: Optional[torch.device] = None,
+                      apply_padding: bool = True) -> Interaction:
     """
     A tool to dump the interaction between Sender and Receiver
     :param game: A Game instance
     :param dataset: Dataset of inputs to be used when analyzing the communication
-    :param gs: whether Gumbel-Softmax relaxation was used during training
-    :param variable_length: whether variable-length communication is used
-    :param device: device (e.g. 'cuda') to be used
-    :return:
+    :param gs: whether the messages should be argmaxed over the last dimension. 
+        Handy, if Gumbel-Softmax relaxation was used for training.
+    :param variable_length: whether variable-length communication is used.
+    :param device: device (e.g. 'cuda') to be used.
+    :return: The entire log of agent interactions, represented as an Interaction instance.
     """
     train_state = game.training  # persist so we restore it back
     game.eval()
-
     device = device if device is not None else common_opts.device
-
-    sender_inputs, messages, receiver_inputs, receiver_outputs = [], [], [], []
-    labels = []
+    full_interaction = None
 
     with torch.no_grad():
         for batch in dataset:
-            # by agreement, each batch is (sender_input, labels) plus optional (receiver_input)
-            sender_input = move_to(batch[0], device)
-            receiver_input = None if len(batch) == 2 else move_to(batch[2], device)
+            batch = move_to(batch, device)
+            _, interaction = game(*batch)
+            interaction = interaction.to('cpu')
 
-            message = game.sender(sender_input)
+            if gs:
+                interaction.message = interactions.message.argmax(dim=-1)  # actual symbols instead of one-hot encoded
+            if apply_padding and variable_length:
+                assert interaction.message_length is not None
+                for i in range(interactions.bsz):
+                    l = interaction.message_length[i]
+                    interaction.message[i, l:] = 0 # 0 is always EOS
 
-            # Under GS, the only output is a message; under Reinforce, two additional tensors are returned.
-            # We don't need them.
-            if not gs: message = message[0]
-
-            output = game.receiver(message, receiver_input)
-            if not gs: output = output[0]
-
-            if batch[1] is not None:
-                labels.extend(batch[1])
-
-            if isinstance(sender_input, list) or isinstance(sender_input, tuple):
-                sender_inputs.extend(zip(*sender_input))
-            else:
-                sender_inputs.extend(sender_input)
-
-            if receiver_input is not None:
-                receiver_inputs.extend(receiver_input)
-
-            if gs: message = message.argmax(dim=-1)  # actual symbols instead of one-hot encoded
-
-            if not variable_length:
-                messages.extend(message)
-                receiver_outputs.extend(output)
-            else:
-                # A trickier part is to handle EOS in the messages. It also might happen that not every message has EOS.
-                # We cut messages at EOS if it is present or return the entire message otherwise. Note, EOS id is always
-                # set to 0.
-
-                for i in range(message.size(0)):
-                    eos_positions = (message[i, :] == 0).nonzero()
-                    message_end = eos_positions[0].item() if eos_positions.size(0) > 0 else -1
-                    assert message_end == -1 or message[i, message_end] == 0
-                    if message_end < 0:
-                        messages.append(message[i, :])
-                    else:
-                        messages.append(message[i, :message_end + 1])
-
-                    if gs:
-                        receiver_outputs.append(output[i, message_end, ...])
-                    else:
-                        receiver_outputs.append(output[i, ...])
+            full_interaction = full_interaction + interaction if full_interaction is not None else interaction
 
     game.train(mode=train_state)
-
-    return sender_inputs, messages, receiver_inputs, receiver_outputs, labels
+    return interaction
 
 
 def move_to(x: Any, device: torch.device) \

--- a/egg/core/util.py
+++ b/egg/core/util.py
@@ -200,7 +200,7 @@ def dump_interactions(game: torch.nn.Module,
                 interaction.message = interaction.message.argmax(dim=-1)  # actual symbols instead of one-hot encoded
             if apply_padding and variable_length:
                 assert interaction.message_length is not None
-                for i in range(interaction.bsz):
+                for i in range(interaction.size):
                     l = interaction.message_length[i].long().item()
                     interaction.message[i, l:] = 0 # 0 is always EOS
 

--- a/egg/zoo/channel/train.py
+++ b/egg/zoo/channel/train.py
@@ -88,7 +88,7 @@ def dump(game, n_features, device, gs_mode):
     powerlaw_probs = 1 / np.arange(1, n_features+1, dtype=np.float32)
     powerlaw_probs /= powerlaw_probs.sum()
 
-    for i in range(interaction.size()):
+    for i in range(interaction.size):
         sender_input = interaction.sender_input[i]
         message = interaction.message[i]
         receiver_output = interaction.receiver_output[i]

--- a/egg/zoo/channel/train.py
+++ b/egg/zoo/channel/train.py
@@ -81,15 +81,18 @@ def dump(game, n_features, device, gs_mode):
     # tiny "dataset"
     dataset = [[torch.eye(n_features).to(device), None]]
 
-    sender_inputs, messages, receiver_inputs, receiver_outputs, _ = \
-        core.dump_sender_receiver(game, dataset, gs=gs_mode, device=device, variable_length=True)
+    interaction = core.dump_interactions(game, dataset, gs=gs_mode, device=device, variable_length=True)
 
     unif_acc = 0.
     powerlaw_acc = 0.
     powerlaw_probs = 1 / np.arange(1, n_features+1, dtype=np.float32)
     powerlaw_probs /= powerlaw_probs.sum()
 
-    for sender_input, message, receiver_output in zip(sender_inputs, messages, receiver_outputs):
+    for i in range(interaction.size()):
+        sender_input = interaction.sender_input[i]
+        message = interaction.message[i]
+        receiver_output = interaction.receiver_output[i]
+
         input_symbol = sender_input.argmax()
         output_symbol = receiver_output.argmax()
         acc = (input_symbol == output_symbol).float().item()

--- a/egg/zoo/compo_vs_generalization/intervention.py
+++ b/egg/zoo/compo_vs_generalization/intervention.py
@@ -191,10 +191,10 @@ class Evaluator(core.Callback):
 
                 batch = core.move_to(batch, self.device)
                 with torch.no_grad():
-                    _, rest = game(*batch)
-                acc += rest['acc']
+                    _, interaction = game(*batch)
+                acc += interaction.aux['acc'].mean().item()
 
-                acc_or += rest['acc_or']
+                acc_or += interaction.aux['acc_or'].mean().item()
             self.results[loader_name] = {
                 'acc': acc / n_batches, 'acc_or': acc_or / n_batches}
 

--- a/egg/zoo/compo_vs_generalization/train.py
+++ b/egg/zoo/compo_vs_generalization/train.py
@@ -193,7 +193,7 @@ def main(params):
     trainer.train(n_epochs=opts.n_epochs)
 
     last_epoch_interactions = early_stopper.validation_stats[-1][1]
-    normalizer = sum(x.sender_input.size(0) for x in last_epoch_interactions)
+    normalizer = sum(x.bsz for x in last_epoch_interactions)
     validation_acc = sum(x.aux['acc'].sum() for x in last_epoch_interactions) / normalizer
 
     uniformtest_acc = holdout_evaluator.results['uniform holdout']['acc']

--- a/egg/zoo/compo_vs_generalization/train.py
+++ b/egg/zoo/compo_vs_generalization/train.py
@@ -99,9 +99,9 @@ class DiffLoss(torch.nn.Module):
             acc_or /= self.n_attributes
         else:
             acc = (torch.sum((receiver_output.argmax(dim=-1) == sender_input.argmax(dim=-1)
-                              ).detach(), dim=1) == self.n_attributes).float().mean()
+                              ).detach(), dim=1) == self.n_attributes).float()#.mean()
             acc_or = (receiver_output.argmax(dim=-1) ==
-                      sender_input.argmax(dim=-1)).float().mean()
+                      sender_input.argmax(dim=-1)).float()#.mean()
 
             receiver_output = receiver_output.view(
                 batch_size * self.n_attributes, self.n_values)
@@ -192,7 +192,10 @@ def main(params):
                    holdout_evaluator])
     trainer.train(n_epochs=opts.n_epochs)
 
-    validation_acc = early_stopper.validation_stats[-1][1]['acc']
+    last_epoch_interactions = early_stopper.validation_stats[-1][1]
+    normalizer = sum(x.sender_input.size(0) for x in last_epoch_interactions)
+    validation_acc = sum(x.aux['acc'].sum() for x in last_epoch_interactions) / normalizer
+
     uniformtest_acc = holdout_evaluator.results['uniform holdout']['acc']
 
     # Train new agents

--- a/egg/zoo/compo_vs_generalization/train.py
+++ b/egg/zoo/compo_vs_generalization/train.py
@@ -99,9 +99,9 @@ class DiffLoss(torch.nn.Module):
             acc_or /= self.n_attributes
         else:
             acc = (torch.sum((receiver_output.argmax(dim=-1) == sender_input.argmax(dim=-1)
-                              ).detach(), dim=1) == self.n_attributes).float()#.mean()
+                              ).detach(), dim=1) == self.n_attributes).float()
             acc_or = (receiver_output.argmax(dim=-1) ==
-                      sender_input.argmax(dim=-1)).float()#.mean()
+                      sender_input.argmax(dim=-1)).float()
 
             receiver_output = receiver_output.view(
                 batch_size * self.n_attributes, self.n_values)

--- a/egg/zoo/compo_vs_generalization/train.py
+++ b/egg/zoo/compo_vs_generalization/train.py
@@ -192,9 +192,8 @@ def main(params):
                    holdout_evaluator])
     trainer.train(n_epochs=opts.n_epochs)
 
-    last_epoch_interactions = early_stopper.validation_stats[-1][1]
-    normalizer = sum(x.bsz for x in last_epoch_interactions)
-    validation_acc = sum(x.aux['acc'].sum() for x in last_epoch_interactions) / normalizer
+    last_epoch_interaction = early_stopper.validation_stats[-1][1]
+    validation_acc = last_epoch_interaction.aux['acc'].mean()
 
     uniformtest_acc = holdout_evaluator.results['uniform holdout']['acc']
 

--- a/egg/zoo/compositional_efficiency/discrete.py
+++ b/egg/zoo/compositional_efficiency/discrete.py
@@ -80,9 +80,10 @@ class DiffLoss(torch.nn.Module):
             assert False
 
         acc = (torch.sum((receiver_output.argmax(dim=-1) ==
-                          sender_input).detach(), dim=1) == self.n_attributes).float().mean()
+                          sender_input).detach(), dim=1) == self.n_attributes).float()
         acc_or = (receiver_output.argmax(dim=-1)
-                  == sender_input).float().mean()
+                  == sender_input).float()
+
 
         receiver_output = receiver_output.view(
             batch_size * self.n_attributes, self.n_values)

--- a/egg/zoo/external_game/game.py
+++ b/egg/zoo/external_game/game.py
@@ -80,7 +80,7 @@ def dump(game, dataset, device, is_gs):
     interaction = \
         core.dump_interactions(game, dataset, gs=is_gs, device=device, variable_length=True)
 
-    for i in range(interaction.bsz): # TODO: make it size
+    for i in range(interaction.size):
         sender_input = interaction.sender_input[i] 
         message = interaction.message[i]
         receiver_output = interaction.receiver_output[i]

--- a/egg/zoo/external_game/game.py
+++ b/egg/zoo/external_game/game.py
@@ -77,13 +77,18 @@ def get_params():
 
 
 def dump(game, dataset, device, is_gs):
-    sender_inputs, messages, _, receiver_outputs, labels = \
-        core.dump_sender_receiver(game, dataset, gs=is_gs, device=device, variable_length=True)
+    interaction = \
+        core.dump_interactions(game, dataset, gs=is_gs, device=device, variable_length=True)
 
-    for sender_input, message, receiver_output, label \
-            in zip(sender_inputs, messages, receiver_outputs, labels):
+    for i in range(interaction.bsz): # TODO: make it size
+        sender_input = interaction.sender_input[i] 
+        message = interaction.message[i]
+        receiver_output = interaction.receiver_output[i]
+        label = interaction.labels[i]
+        length = interaction.message_length[i]
+
         sender_input = ' '.join(map(str, sender_input.tolist()))
-        message = ' '.join(map(str, message.tolist()))
+        message = ' '.join(map(str, message[:length].tolist()))
         if is_gs: receiver_output = receiver_output.argmax()
         print(f'{sender_input};{message};{receiver_output};{label.item()}')
 

--- a/egg/zoo/external_game/game.py
+++ b/egg/zoo/external_game/game.py
@@ -85,7 +85,7 @@ def dump(game, dataset, device, is_gs):
         message = interaction.message[i]
         receiver_output = interaction.receiver_output[i]
         label = interaction.labels[i]
-        length = interaction.message_length[i]
+        length = interaction.message_length[i].long().item()
 
         sender_input = ' '.join(map(str, sender_input.tolist()))
         message = ' '.join(map(str, message[:length].tolist()))

--- a/egg/zoo/language_bottleneck/intervention.py
+++ b/egg/zoo/language_bottleneck/intervention.py
@@ -233,9 +233,9 @@ class CallbackEvaluator(core.Callback):
             core.dump_interactions(game, self.dataset, gs=self.is_gs, device=self.device,
                                       variable_length=self.var_length)
 
-        messages = [interactions.message[i] for i in range(interactions.bsz)]
+        messages = [interactions.message[i] for i in range(interactions.size)]
         entropy_messages = entropy(messages)
-        labels = [interactions.labels[i] for i in range(interactions.bsz)]
+        labels = [interactions.labels[i] for i in range(interactions.size)]
 
         message_mapping = {}
 

--- a/egg/zoo/language_bottleneck/intervention.py
+++ b/egg/zoo/language_bottleneck/intervention.py
@@ -229,11 +229,13 @@ class CallbackEvaluator(core.Callback):
         self.epoch += 1
 
     def validation(self, game):
-        sender_inputs, messages, _, receiver_outputs, labels = \
-            core.dump_sender_receiver(game, self.dataset, gs=self.is_gs, device=self.device,
+        interactions = \
+            core.dump_interactions(game, self.dataset, gs=self.is_gs, device=self.device,
                                       variable_length=self.var_length)
 
+        messages = [interactions.message[i] for i in range(interactions.bsz)]
         entropy_messages = entropy(messages)
+        labels = [interactions.labels[i] for i in range(interactions.bsz)]
 
         message_mapping = {}
 

--- a/egg/zoo/language_bottleneck/mnist_adv/train.py
+++ b/egg/zoo/language_bottleneck/mnist_adv/train.py
@@ -19,7 +19,7 @@ from egg.zoo.language_bottleneck.mnist_classification.data import DoubleMnist
 
 def diff_loss_symbol(_sender_input, _message, _receiver_input, receiver_output, labels):
     loss = F.nll_loss(receiver_output, labels, reduction='none').mean()
-    acc = (receiver_output.argmax(dim=1) == labels).float().mean()
+    acc = (receiver_output.argmax(dim=1) == labels).float()
     return loss, {'acc': acc}
 
 

--- a/egg/zoo/language_bottleneck/mnist_classification/train.py
+++ b/egg/zoo/language_bottleneck/mnist_classification/train.py
@@ -61,8 +61,7 @@ def main(params):
     sender = core.GumbelSoftmaxWrapper(sender, temperature=opts.temperature)
 
     logging_strategy = core.LoggingStrategy(store_sender_input=False)
-
-    game = core.SymbolGameGS(sender, receiver, diff_loss_symbol)
+    game = core.SymbolGameGS(sender, receiver, diff_loss_symbol, logging_strategy=logging_strategy)
 
     optimizer = core.build_optimizer(game.parameters())
 

--- a/egg/zoo/language_bottleneck/mnist_classification/train.py
+++ b/egg/zoo/language_bottleneck/mnist_classification/train.py
@@ -19,7 +19,7 @@ from egg.core import EarlyStopperAccuracy
 
 def diff_loss_symbol(_sender_input, _message, _receiver_input, receiver_output, labels):
     loss = F.nll_loss(receiver_output, labels, reduction='none').mean()
-    acc = (receiver_output.argmax(dim=1) == labels).float().mean()
+    acc = (receiver_output.argmax(dim=1) == labels).float()
     return loss, {'acc': acc}
 
 

--- a/egg/zoo/language_bottleneck/mnist_classification/train.py
+++ b/egg/zoo/language_bottleneck/mnist_classification/train.py
@@ -60,6 +60,8 @@ def main(params):
     receiver = Receiver(vocab_size=opts.vocab_size, n_classes=opts.n_labels, n_hidden=opts.n_hidden)
     sender = core.GumbelSoftmaxWrapper(sender, temperature=opts.temperature)
 
+    logging_strategy = core.LoggingStrategy(store_sender_input=False)
+
     game = core.SymbolGameGS(sender, receiver, diff_loss_symbol)
 
     optimizer = core.build_optimizer(game.parameters())

--- a/egg/zoo/language_bottleneck/mnist_overfit/train.py
+++ b/egg/zoo/language_bottleneck/mnist_overfit/train.py
@@ -20,7 +20,7 @@ from egg.core import EarlyStopperAccuracy
 
 def diff_loss_symbol(_sender_input, _message, _receiver_input, receiver_output, labels):
     loss = F.nll_loss(receiver_output, labels, reduction='none').mean()
-    acc = (receiver_output.argmax(dim=1) == labels).float().mean()
+    acc = (receiver_output.argmax(dim=1) == labels).float()
     return loss, {'acc': acc}
 
 

--- a/egg/zoo/mnist_autoenc/train.py
+++ b/egg/zoo/mnist_autoenc/train.py
@@ -87,7 +87,7 @@ def main(params):
 
     # initialize and launch the trainer
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader, validation_data=test_loader,
-                           callbacks=[temperature_updater, core.ConsoleLogger(as_json=True, print_train_loss=True)])
+                           callbacks=[temperature_updater, core.ConsoleLogger(as_json=False, print_train_loss=True)])
     trainer.train(n_epochs=opts.n_epochs)
 
     core.close()

--- a/egg/zoo/mnist_autoenc/train.py
+++ b/egg/zoo/mnist_autoenc/train.py
@@ -87,7 +87,7 @@ def main(params):
 
     # initialize and launch the trainer
     trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader, validation_data=test_loader,
-                           callbacks=[temperature_updater, core.ConsoleLogger(as_json=False, print_train_loss=True)])
+                           callbacks=[temperature_updater, core.ConsoleLogger(as_json=True, print_train_loss=True)])
     trainer.train(n_epochs=opts.n_epochs)
 
     core.close()

--- a/tests/test_toy_counting.py
+++ b/tests/test_toy_counting.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, Path(__file__).parent.parent.resolve().as_posix())
 import egg.core as core
+from egg.core import Interaction
 
 
 class ToyDataset:
@@ -46,7 +47,7 @@ class ToyGame(torch.nn.Module):
         output = self.agent(x)
         output = output.squeeze(1)
         loss = self.criterion(output, y)
-        return loss, {}
+        return loss, Interaction.empty()
 
 
 def test_toy_counting_gradient():

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -48,8 +48,9 @@ class MockGame(torch.nn.Module):
         self.param = torch.nn.Parameter(torch.Tensor([0]))
 
     def forward(self, *args, **kwargs):
-        return self.param, {'acc': 1}
-
+        interaction = core.Interaction.empty()
+        interaction.aux = {'acc': torch.ones(1)}
+        return self.param, interaction
 
 def test_temperature_updater_callback():
     core.init()


### PR DESCRIPTION
We start storing more details about sender->receiver communication: messages, message lengths, receiver outputs, all inputs.
As a result, we would be able to analyse the emergent protocol by passing inputs to the game and running post-analysis within the Callback interface. While before, the only way for doing that would be to re-implement agent interaction in a separate entity (as we do now in `language bottleneck`, `compositionality_vs_generalization`, and `external_game`).

Next, since now Game is responsible for collecting interactions, it has more freedom to encapsulate complex behaviours (sampling agents from populations, multi-hop interactions etc).