### PR TITLE
Returning python3.6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EGG 🐣: Emergence of lanGuage in Games
 
 ![GitHub](https://img.shields.io/github/license/facebookresearch/EGG)
-[![Python 3.6](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
+[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-370/)
 
 ## Introduction
 

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -5,7 +5,6 @@
 
 from typing import Optional, Dict, Union, Iterable
 from dataclasses import dataclass
-from functools import cached_property
 import torch
 
 @dataclass
@@ -51,7 +50,7 @@ class Interaction:
     message_length: Optional[torch.Tensor]
     aux: Dict[str, torch.Tensor]
 
-    @cached_property
+    @property
     def size(self):
         for t in [self.sender_input, self.receiver_input, self.labels, self.message, self.receiver_output, self.message_length]:
             if t is not None: return t.size(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 numpy
 pytest
 editdistance
+dataclasses


### PR DESCRIPTION
Python 3.6 is still used in Colab, hence it's important to be compatible.

See https://github.com/facebookresearch/EGG/issues/94