### PR TITLE
Improving checks for shapes in Reinforce

### DIFF
--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -55,7 +55,13 @@ class ReinforceWrapper(nn.Module):
         return sample, log_prob, entropy
 
 def _verify_batch_sizes(loss, sender_probs, receiver_probs):
+    """Raises an excepption if tensors are not appropriately sized"""
     loss_size, sender_size, receiver_size = loss.size(), sender_probs.size(), receiver_probs.size()
+
+    # Most likely you shouldn't have batch size 1, as Reinforce wouldn't work too well
+    # but it is not incorrect either
+    if loss.numel() == sender_probs.numel() == receiver_probs.numbel() == 1:
+        return 
 
     is_ok = loss_size and sender_size and \
         loss_size[0] == sender_size[0]
@@ -66,6 +72,8 @@ def _verify_batch_sizes(loss, sender_probs, receiver_probs):
                            "action log-probabilities returned by Sender. However, currently shapes are "
                            f"{loss_size} and {sender_size}.")
 
+    # As Receiver can be deterministic (and have constant zero log-probs for all its actions)
+    # we allow them to be a scalar tensor
     is_receiver_ok = (receiver_probs.numel() == 1 and receiver_probs.item() == 0.0) or \
             (receiver_probs.numel() > 1 and receiver_size[0] == loss_size[0])
     if not is_receiver_ok:

--- a/egg/zoo/compositional_efficiency/continuous.py
+++ b/egg/zoo/compositional_efficiency/continuous.py
@@ -38,7 +38,7 @@ def get_params(params):
 
 
 def diff_loss(sender_input, _message, _receiver_input, receiver_output, _labels):
-    loss = F.mse_loss(receiver_output, sender_input)
+    loss = F.mse_loss(receiver_output, sender_input, reduction='none').mean(-1)
     return loss, {}
 
 

--- a/tests/test_agent_wrappers.py
+++ b/tests/test_agent_wrappers.py
@@ -110,7 +110,7 @@ def test_game_reinforce():
     receiver = core.ReinforceDeterministicWrapper(Receiver())
 
     loss = lambda sender_input, message, receiver_input, receiver_output, labels: \
-        (-(receiver_output == labels).float().mean(), {})
+        (-(receiver_output == labels).float(), {})
 
     game = core.SymbolGameReinforce(sender, receiver, loss, sender_entropy_coeff=1e-1, receiver_entropy_coeff=0.0)
     optimizer = torch.optim.Adagrad(game.parameters(), lr=1e-1)


### PR DESCRIPTION
The existing check (`_verify_batch_size`) is a bit too strict:

- It is OK for Receiver to return zero-scalar constant as log-probs
- It is OK to use wrongly-shaped losses as long as they are only used in evaluation

On top of that, a couple fixes for places where the check was triggered.