### PR TITLE
Fixed bug in calculating topological similarity

### DIFF
--- a/egg/core/language_analysis.py
+++ b/egg/core/language_analysis.py
@@ -98,7 +98,7 @@ class MessageEntropy(Callback):
 
 
 class TopographicSimilarity(Callback):
-    distances = {'edit': lambda x, y: editdistance.eval(x, y) / (len(x) + len(y)) / 2,
+    distances = {'edit': lambda x, y: editdistance.eval(x, y) / ((len(x) + len(y)) / 2),
                  'cosine': distance.cosine,
                  'hamming': distance.hamming,
                  'jaccard': distance.jaccard,


### PR DESCRIPTION
Previous the maximum of the implemented edit distance is 0.25, which would makes the correlation between it with other measurements smaller than the true one. 

To be specific, `editdistance.eval(x, y) / (len(x) + len(y))` would be expected to 0.5, thus `editdistance.eval(x, y) / (len(x) + len(y)) / 2` would be at most 0.25. I guess that the implementation was meant to be `editdistance.eval(x, y) / ((len(x) + len(y)) / 2)` 