### PR TITLE
Putting cached lengths on CPU before calling RNN

### DIFF
--- a/egg/core/rnn.py
+++ b/egg/core/rnn.py
@@ -69,7 +69,7 @@ class RnnEncoder(nn.Module):
             lengths = find_lengths(message)
 
         packed = nn.utils.rnn.pack_padded_sequence(
-            emb, lengths, batch_first=True, enforce_sorted=False
+            emb, lengths.cpu(), batch_first=True, enforce_sorted=False
         )
         _, rnn_hidden = self.cell(packed)
 


### PR DESCRIPTION
In pytorch 1.7 `nn.utils.rnn.pack_padded_sequence` crashes when passing cuda-placed lengths (before, it they were implicitly copied over).


## Description
Copying over to CPU.

## How Has This Been Tested?
UTs pass.