### PR TITLE
Mixed precision training

### DIFF
--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -6,7 +6,13 @@
 import os
 import pathlib
 from typing import List, Optional
-from contextlib import nullcontext
+try:
+    # requires python >= 3.7
+    from contextlib import nullcontext
+except ImportError:
+    # not exactly the same, but will do for our purposes
+    from contextlib import suppress as nullcontext
+
 
 import torch
 from torch.utils.data import DataLoader

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -6,13 +6,13 @@
 import os
 import pathlib
 from typing import List, Optional
+
 try:
     # requires python >= 3.7
     from contextlib import nullcontext
 except ImportError:
     # not exactly the same, but will do for our purposes
     from contextlib import suppress as nullcontext
-
 
 import torch
 from torch.utils.data import DataLoader
@@ -32,6 +32,7 @@ try:
     from torch.cuda.amp import GradScaler, autocast
 except ImportError:
     pass
+
 
 class Trainer:
     """
@@ -192,7 +193,7 @@ class Trainer:
             batch = move_to(batch, self.device)
 
             context = autocast() if self.scaler else nullcontext()
-            with context: 
+            with context:
                 optimized_loss, interaction = self.game(*batch)
 
                 if self.update_freq > 1:
@@ -206,7 +207,8 @@ class Trainer:
                 optimized_loss.backward()
 
             if batch_id % self.update_freq == self.update_freq - 1:
-                if self.scaler: self.scaler.unscale_(self.optimizer)
+                if self.scaler:
+                    self.scaler.unscale_(self.optimizer)
 
                 if self.grad_norm:
                     torch.nn.utils.clip_grad_norm_(
@@ -217,7 +219,7 @@ class Trainer:
                     self.scaler.update()
                 else:
                     self.optimizer.step()
-                    
+
                 self.optimizer.zero_grad()
 
             n_batches += 1

--- a/egg/core/util.py
+++ b/egg/core/util.py
@@ -120,7 +120,10 @@ def _populate_cl_params(arg_parser: argparse.ArgumentParser) -> argparse.Argumen
     )
 
     arg_parser.add_argument(
-        "--fp16", default=False, help="Use mixed-precision for training/evaluating models", action="store_true"
+        "--fp16",
+        default=False,
+        help="Use mixed-precision for training/evaluating models",
+        action="store_true",
     )
 
     return arg_parser
@@ -136,8 +139,8 @@ def _get_params(
     args.device = torch.device("cuda" if args.cuda else "cpu")
     args.distributed_context = maybe_init_distributed(args)
 
-    if args.fp16 and torch.__version__ < '1.6.0':
-        print('--fp16 is only supported with pytorch >= 1.6.0, please update!')
+    if args.fp16 and torch.__version__ < "1.6.0":
+        print("--fp16 is only supported with pytorch >= 1.6.0, please update!")
         args.fp16 = False
 
     return args

--- a/egg/core/util.py
+++ b/egg/core/util.py
@@ -119,6 +119,10 @@ def _populate_cl_params(arg_parser: argparse.ArgumentParser) -> argparse.Argumen
         help="Port to use in distributed learning",
     )
 
+    arg_parser.add_argument(
+        "--fp16", default=False, help="Use mixed-precision for training/evaluating models", action="store_true"
+    )
+
     return arg_parser
 
 
@@ -131,6 +135,10 @@ def _get_params(
     args.no_cuda = not args.cuda
     args.device = torch.device("cuda" if args.cuda else "cpu")
     args.distributed_context = maybe_init_distributed(args)
+
+    if args.fp16 and torch.__version__ < '1.6.0':
+        print('--fp16 is only supported with pytorch >= 1.6.0, please update!')
+        args.fp16 = False
 
     return args
 


### PR DESCRIPTION
Enables mixed-precision training when `--fp16` is specified.

## Description
Uses pytorch.cuda.amp primitives in Trainer.

## Related Issue (if any)
https://github.com/facebookresearch/EGG/issues/165

## Motivation and Context
/a/ Reduces mem-consumption, which could be interesting if you run REINFORCE on for under-powered GPUs
/b/ Must give a speed-up on modern GPUs (eg Volta) (however, I didn't test that)

## How Has This Been Tested?
/1/ Manually checked convergence on the channel (zipfian) game
/2/ Checked that it unlocks ~2x larger batch size on language_bottleneck/image_classification