### PR TITLE
save sender/receiver instead of game in checkpoint

### DIFF
--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -118,7 +118,8 @@ class TemperatureUpdater(Callback):
 
 class Checkpoint(NamedTuple):
     epoch: int
-    model_state_dict: Dict[str, Any]
+    sender_state_dict: Dict[str, Any]
+    receiver_state_dict: Dict[str, Any]
     optimizer_state_dict: Dict[str, Any]
 
 
@@ -162,7 +163,8 @@ class CheckpointSaver(Callback):
     def get_checkpoint(self):
         return Checkpoint(
             epoch=self.epoch_counter,
-            model_state_dict=self.trainer.game.state_dict(),
+            sender_state_dict=self.trainer.game.sender.state_dict(),
+            receiver_state_dict=self.trainer.game.receiver.state_dict(),
             optimizer_state_dict=self.trainer.optimizer.state_dict(),
         )
 

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -281,7 +281,8 @@ class Trainer:
             callback.on_train_end()
 
     def load(self, checkpoint: Checkpoint):
-        self.game.load_state_dict(checkpoint.model_state_dict)
+        self.game.sender.load_state_dict(checkpoint.sender_state_dict)
+        self.game.receiver.load_state_dict(checkpoint.receiver_state_dict)
         self.optimizer.load_state_dict(checkpoint.optimizer_state_dict)
         self.start_epoch = checkpoint.epoch
 


### PR DESCRIPTION
## Description
Decoupling sender/receiver from Game when loading/storing a checkpoint.
Useful for post-training analysis. This way when we load the model we don't have to do things like define a new game, passing a (dummy?) loss. We would have straight access to sender/receiver compared to accessing them through game.sender or game.receiver. Note that the latter is not compatible with the experimental implementation of PopulationGame as that class has only two fields: a sampler and a game field. So loading a game and accessing game.sender or game.receiver causes a crash. The user knows before hand what kind of game s/he's loading so not sure this is really a problem. 
On the other hand, I have not yet thought how to handle cases like the PopulationGame when storing a model. Should we store all agents in the populations individually? Not really feasible or smart.

## Related Issue (if any)
#148, #150 

## Motivation and Context
Useful for language analysis or for manually feeding sender/receiver input/messages