### PR TITLE
Extend CheckpointSaver class

### DIFF
--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -4,7 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
+import os
 import pathlib
+import re
+import sys
 import time
 from typing import Any, Dict, List, NamedTuple, Union
 
@@ -131,11 +134,23 @@ class CheckpointSaver(Callback):
         checkpoint_path: Union[str, pathlib.Path],
         checkpoint_freq: int = 1,
         prefix: str = "",
+        start_epoch: int = 0,
+        max_chk: int = sys.maxsize,
     ):
+        """Saves a checkpoint file for training
+        Arguments:
+            checkpoint_path {Union[str, pathlib.Path]} -- path to checkpoint directory, will be created if not present
+            checkpoint_freq {int} -- Number of epochs for checkpoint saving
+            prefix {str} -- Name of checkpoint file, will be {prefix}{current_epoch}.tar
+            start_epoch {int} -- For resuming training you can either use Trainer.load_from_latest or specify the epoch
+             here
+            max_chk {int} -- Max number of concurrent checkpoint files in the directory.
+        """
         self.checkpoint_path = pathlib.Path(checkpoint_path)
         self.checkpoint_freq = checkpoint_freq
         self.prefix = prefix
-        self.epoch_counter = 0
+        self.epoch_counter = start_epoch
+        self.max_chk_keep = max_chk
 
     def on_epoch_end(self, loss: float, logs: Interaction, epoch: int):
         self.epoch_counter = epoch
@@ -159,6 +174,8 @@ class CheckpointSaver(Callback):
         Saves the game, agents, and optimizer states to the checkpointing path under `<number_of_epochs>.tar` name
         """
         self.checkpoint_path.mkdir(exist_ok=True, parents=True)
+        if len(self.get_chk_files()) > self.max_chk_keep:
+            self.remove_old_chk()
         path = self.checkpoint_path / f"{filename}.tar"
         torch.save(self.get_checkpoint(), path)
 
@@ -168,6 +185,30 @@ class CheckpointSaver(Callback):
             model_state_dict=self.trainer.game.state_dict(),
             optimizer_state_dict=self.trainer.optimizer.state_dict(),
         )
+
+    def get_chk_files(self):
+        """
+        Return a list of the files in the checkpoint dir
+        """
+        return [name for name in os.listdir(self.checkpoint_path) if ".tar" in name]
+
+    @staticmethod
+    def natural_sort(to_sort):
+        """
+        Sort a list of files naturally
+        E.g. [file1,file4,file32,file2] -> [file1,file2,file4,file32]
+        """
+        convert = lambda text: int(text) if text.isdigit() else text.lower()
+        alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
+        return sorted(to_sort, key=alphanum_key)
+
+    def remove_old_chk(self):
+        """
+        Remove the oldest checkpoint from the dir
+        """
+        chk_points = self.natural_sort(self.get_chk_files())
+        to_remove = chk_points[0]
+        os.remove(os.path.join(self.checkpoint_path, to_remove))
 
 
 class InteractionSaver(Callback):

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -170,7 +170,7 @@ class CheckpointSaver(Callback):
         Saves the game, agents, and optimizer states to the checkpointing path under `<number_of_epochs>.tar` name
         """
         self.checkpoint_path.mkdir(exist_ok=True, parents=True)
-        if len(self.get_checkpoint_files()) > self.max_checkpoints_keep:
+        if len(self.get_checkpoint_files()) > self.max_checkpoints:
             self.remove_old_chk()
         path = self.checkpoint_path / f"{filename}.tar"
         torch.save(self.get_checkpoint(), path)

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -145,7 +145,7 @@ class CheckpointSaver(Callback):
         self.checkpoint_path = pathlib.Path(checkpoint_path)
         self.checkpoint_freq = checkpoint_freq
         self.prefix = prefix
-        self.max_checkpoints_keep = max_checkpoints
+        self.max_checkpoints = max_checkpoints
         self.epoch_counter = 0
 
     def on_epoch_end(self, loss: float, logs: Interaction, epoch: int):

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -137,10 +137,10 @@ class CheckpointSaver(Callback):
         max_checkpoints: int = sys.maxsize,
     ):
         """Saves a checkpoint file for training.
-            :param checkpoint_path:  path to checkpoint directory, will be created if not present
-            :param checkpoint_freq:  Number of epochs for checkpoint saving
-            :param prefix: Name of checkpoint file, will be {prefix}{current_epoch}.tar
-            :param max_checkpoints: Max number of concurrent checkpoint files in the directory.
+        :param checkpoint_path:  path to checkpoint directory, will be created if not present
+        :param checkpoint_freq:  Number of epochs for checkpoint saving
+        :param prefix: Name of checkpoint file, will be {prefix}{current_epoch}.tar
+        :param max_checkpoints: Max number of concurrent checkpoint files in the directory.
         """
         self.checkpoint_path = pathlib.Path(checkpoint_path)
         self.checkpoint_freq = checkpoint_freq
@@ -150,14 +150,8 @@ class CheckpointSaver(Callback):
 
     def on_epoch_end(self, loss: float, logs: Interaction, epoch: int):
         self.epoch_counter = epoch
-        if self.checkpoint_freq > 0 and (
-            self.epoch_counter % self.checkpoint_freq == 0
-        ):
-            filename = (
-                f"{self.prefix}_{self.epoch_counter}"
-                if self.prefix
-                else str(self.epoch_counter)
-            )
+        if self.checkpoint_freq > 0 and (epoch % self.checkpoint_freq == 0):
+            filename = f"{self.prefix}_{epoch}" if self.prefix else str(epoch)
             self.save_checkpoint(filename=filename)
 
     def on_train_end(self):
@@ -171,7 +165,7 @@ class CheckpointSaver(Callback):
         """
         self.checkpoint_path.mkdir(exist_ok=True, parents=True)
         if len(self.get_checkpoint_files()) > self.max_checkpoints:
-            self.remove_old_chk()
+            self.remove_oldest_checkpoint()
         path = self.checkpoint_path / f"{filename}.tar"
         torch.save(self.get_checkpoint(), path)
 
@@ -202,9 +196,8 @@ class CheckpointSaver(Callback):
         """
         Remove the oldest checkpoint from the dir
         """
-        chk_points = self.natural_sort(self.get_checkpoint_files())
-        to_remove = chk_points[0]
-        os.remove(os.path.join(self.checkpoint_path, to_remove))
+        checkpoints = self.natural_sort(self.get_checkpoint_files())
+        os.remove(os.path.join(self.checkpoint_path, checkpoints[0]))
 
 
 class InteractionSaver(Callback):

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -198,7 +198,7 @@ class CheckpointSaver(Callback):
         alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
         return sorted(to_sort, key=alphanum_key)
 
-    def remove_old_chk(self):
+    def remove_oldest_checkpoint(self):
         """
         Remove the oldest checkpoint from the dir
         """

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -97,16 +97,16 @@ def test_snapshoting():
         optimizer,
         train_data=data,
         validation_data=None,
-        callbacks=[core.CheckpointSaver(checkpoint_path=CHECKPOINT_PATH)],
+        callbacks=[core.CheckpointSaver(checkpoint_path=CHECKPOINT_PATH, max_chk=2)],
     )
-    trainer.train(2)
-    assert (CHECKPOINT_PATH / Path("1.tar")).exists()
-    assert (CHECKPOINT_PATH / Path("2.tar")).exists()
+    trainer.train(n_epochs=6)
+    assert (CHECKPOINT_PATH / Path("5.tar")).exists()
+    assert (CHECKPOINT_PATH / Path("6.tar")).exists()
     assert (CHECKPOINT_PATH / Path("final.tar")).exists()
     del trainer
     trainer = core.Trainer(game, optimizer, train_data=data)  # Re-instantiate trainer
     trainer.load_from_latest(CHECKPOINT_PATH)
-    assert trainer.start_epoch == 2
+    assert trainer.start_epoch == 6
     trainer.train(3)
     shutil.rmtree(CHECKPOINT_PATH)  # Clean-up
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -97,7 +97,7 @@ def test_snapshoting():
         optimizer,
         train_data=data,
         validation_data=None,
-        callbacks=[core.CheckpointSaver(checkpoint_path=CHECKPOINT_PATH, max_chk=2)],
+        callbacks=[core.CheckpointSaver(checkpoint_path=CHECKPOINT_PATH, max_checkpoints=2)],
     )
     trainer.train(n_epochs=6)
     assert (CHECKPOINT_PATH / Path("5.tar")).exists()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -2,8 +2,6 @@
 
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
-
 import shutil
 import sys
 from pathlib import Path
@@ -131,14 +129,17 @@ def test_max_snapshoting():
         optimizer,
         train_data=data,
         validation_data=None,
-        callbacks=[core.CheckpointSaver(checkpoint_path=CHECKPOINT_PATH, max_checkpoints=2)],
+        callbacks=[
+            core.CheckpointSaver(checkpoint_path=CHECKPOINT_PATH, max_checkpoints=2)
+        ],
     )
     trainer.train(n_epochs=6)
     assert (CHECKPOINT_PATH / Path("5.tar")).exists()
     assert (CHECKPOINT_PATH / Path("6.tar")).exists()
     assert (CHECKPOINT_PATH / Path("final.tar")).exists()
+    assert len([x for x in CHECKPOINT_PATH.glob("**/*") if x.is_file()]) == 3
     del trainer
-   
+
 
 def test_early_stopping():
     game, data = MockGame(), Dataset()


### PR DESCRIPTION
Extended the CheckpointSaver to add the following:
- possibility to define the starting epoch. This comes in handy when you do not want to use the Trainer.load_checkpoint.
- Define a max checkpoint files to keep at the same time. For big enough model and many epochs the checkpoint directory may become saturated with too many heavy files. With this functionality a max number of files are allowed in the directory at the same time. Oldest checkpoints are deleted first.