### PR TITLE
add support for population-based training

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Generally, we assume that you use PyTorch 1.1.0 or newer and Python 3.6 or newer
 
  1. (optional) It is a good idea to develop in a new conda environment, e.g. like this:
     ```
-    conda create --name egg37 python=3.7
-    conda activate egg37
+    conda create --name egg36 python=3.6
+    conda activate egg36
     ```
  2. EGG can be installed as a package to be used as a library
     ```

--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -30,6 +30,7 @@ from .language_analysis import (
     TopographicSimilarity,
 )
 from .reinforce_wrappers import (
+    CommunicationRnnReinforce,
     ReinforceDeterministicWrapper,
     ReinforceWrapper,
     RnnReceiverDeterministic,
@@ -75,6 +76,7 @@ __all__ = [
     "RnnReceiverReinforce",
     "RnnSenderReinforce",
     "SenderReceiverRnnReinforce",
+    "CommunicationRnnReinforce",
     "RnnReceiverDeterministic",
     "RnnSenderGS",
     "RnnReceiverGS",

--- a/egg/core/population.py
+++ b/egg/core/population.py
@@ -1,0 +1,72 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.nn as nn
+import random
+import numpy as np
+import itertools
+
+
+class UniformAgentSampler(nn.Module):
+    # NB: only a module to facilitate checkpoint persistance
+    def __init__(self, senders, receivers, losses):
+        super().__init__()
+
+        self.senders = nn.ModuleList(senders)
+        self.receivers = nn.ModuleList(receivers)
+        self.losses = list(losses)
+
+    def forward(self):
+        return (
+            random.choice(self.senders),
+            random.choice(self.receivers),
+            random.choice(self.losses),
+        )
+
+
+class FullSweepAgentSampler(nn.Module):
+    # NB: only a module to facilitate checkpoint persistance
+    def __init__(self, senders, receivers, losses):
+        super().__init__()
+
+        self.senders = nn.ModuleList(senders)
+        self.receivers = nn.ModuleList(receivers)
+        self.losses = list(losses)
+
+        self.senders_order = list(range(len(self.senders)))
+        self.receivers_order = list(range(len(self.receivers)))
+        self.losses_order = list(range(len(self.losses)))
+
+        self.reset_order()
+
+    def reset_order(self):
+        np.random.shuffle(self.senders_order)
+        np.random.shuffle(self.receivers_order)
+        np.random.shuffle(self.losses_order)
+
+        self.iterator = itertools.product(
+            self.senders_order, self.receivers_order, self.losses_order
+        )
+
+    def forward(self):
+        try:
+            s, r, l = next(self.iterator)
+        except StopIteration:
+            self.reset_order()
+            s, r, l = next(self.iterator)
+        return self.senders[s], self.receivers[r], self.losses[l]
+
+
+class PopulationGame(nn.Module):
+    def __init__(self, game, agents_loss_sampler):
+        super().__init__()
+
+        self.game = game
+        self.agents_loss_sampler = agents_loss_sampler
+
+    def forward(self, *args, **kwargs):
+        sender, receiver, loss = self.agents_loss_sampler()
+
+        return self.game(sender, receiver, loss, *args, **kwargs)


### PR DESCRIPTION
## Description
Adding support for population-based training for variable-length reinforce-based training. Credits to @eugene-kharitonov 

Note that signature and methods for variable-length reinforce-based training do not change. Current games using `SenderReceiverRnnReinforce` are not impacted.

## Motivation and Context
Training and supporting multiple listeners and multiple receiver can be useful for population-based (possibly generation-based) games.

## How Has This Been Tested?
UTs with new population file pass (note: these includes games using the SenderReceiverRnnReinforce class)