### PR TITLE
avoid loading model twice when running on slurm

### DIFF
--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -96,7 +96,8 @@ class Trainer:
                 ), "checkpointing directory has to be specified"
                 d = get_preemptive_checkpoint_dir(common_opts.checkpoint_dir)
                 self.checkpoint_path = d
-                self.load_from_latest(d)
+                if not common_opts.load_from_checkpoint:
+                    self.load_from_latest(d)
             else:
                 self.checkpoint_path = (
                     None


### PR DESCRIPTION
## Description
Avoiding loading a model twice potentially from two different checkpoints.

## Motivation and Context
This might be a corner a case but an unwanted model loading happens when all these three conditions are met:
- running under slurm (given the the `--preemptable` flag is set)
- loading a model from a checkpoint (given `--load_from_checkpoint` flag is set)
- a `--checkpoint_dir` is set AND there are some additional existing checkpoints in there. If the latest checkpoint in such folder is different from the one passed through `--load_from_checkpoint`, the former will be overwritten. I expect this to be an unwanted behaviour. 

If a train is launched NOT under slurm but with the `--preemptable` flag is set the overwriting will not happen since EGG will assign a unique name to the checkpoint folder without any existing checkpoints https://github.com/facebookresearch/EGG/blob/5a68e295c31342385d024ecd5cbff0ff69ee69b0/egg/core/distributed.py#L107-L112
and loading from latest will not do anything https://github.com/facebookresearch/EGG/blob/5a68e295c31342385d024ecd5cbff0ff69ee69b0/egg/core/trainers.py#L307-L316

However, launching EGG not under SLURM and with `--preemptable` set is pointless

## How Has This Been Tested?
UTs