### PR TITLE
LR scheduler

### DIFF
--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -10,7 +10,7 @@ import re
 import sys
 import time
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, List, NamedTuple, Union
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
 
 import torch
 from rich.columns import Columns
@@ -140,6 +140,7 @@ class Checkpoint(NamedTuple):
     epoch: int
     model_state_dict: Dict[str, Any]
     optimizer_state_dict: Dict[str, Any]
+    optimizer_scheduler_state_dict: Optional[Dict[str, Any]]
 
 
 class CheckpointSaver(Callback):
@@ -184,10 +185,14 @@ class CheckpointSaver(Callback):
         torch.save(self.get_checkpoint(), path)
 
     def get_checkpoint(self):
+        optimizer_schedule_state_dict = None
+        if self.trainer.optimizer_scheduler:
+            optimizer_schedule_state_dict = self.trainer.optimizer_scheduler.state_dict()
         return Checkpoint(
             epoch=self.epoch_counter,
             model_state_dict=self.trainer.game.state_dict(),
             optimizer_state_dict=self.trainer.optimizer.state_dict(),
+            optimizer_scheduler_state_dict=optimizer_schedule_state_dict
         )
 
     def get_checkpoint_files(self):

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -45,6 +45,7 @@ class Trainer:
         game: torch.nn.Module,
         optimizer: torch.optim.Optimizer,
         train_data: DataLoader,
+        optimizer_scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         validation_data: Optional[DataLoader] = None,
         device: torch.device = None,
         callbacks: Optional[List[Callback]] = None,
@@ -56,6 +57,7 @@ class Trainer:
             where loss is differentiable loss to be minimized and d is a dictionary (potentially empty) with auxiliary
             metrics that would be aggregated and reported
         :param optimizer: An instance of torch.optim.Optimizer
+        :param optimizer_scheduler: An optimizer scheduler to adjust lr throughout training
         :param train_data: A DataLoader for the training set
         :param validation_data: A DataLoader for the validation set (can be None)
         :param device: A torch.device on which to tensors should be stored
@@ -63,6 +65,7 @@ class Trainer:
         """
         self.game = game
         self.optimizer = optimizer
+        self.optimizer_scheduler = optimizer_scheduler
         self.train_data = train_data
         self.validation_data = validation_data
         common_opts = get_opts()
@@ -225,6 +228,8 @@ class Trainer:
                     self.scaler.update()
                 else:
                     self.optimizer.step()
+
+                self.optimizer_scheduler.step()
 
                 self.optimizer.zero_grad()
 

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -229,8 +229,6 @@ class Trainer:
                 else:
                     self.optimizer.step()
 
-                self.optimizer_scheduler.step()
-
                 self.optimizer.zero_grad()
 
             n_batches += 1
@@ -246,6 +244,9 @@ class Trainer:
                 callback.on_batch_end(interaction, optimized_loss, batch_id)
 
             interactions.append(interaction)
+
+        if self.optimizer_scheduler:
+            self.optimizer_scheduler.step()
 
         mean_loss /= n_batches
         full_interaction = Interaction.from_iterable(interactions)
@@ -298,6 +299,8 @@ class Trainer:
     def load(self, checkpoint: Checkpoint):
         self.game.load_state_dict(checkpoint.model_state_dict)
         self.optimizer.load_state_dict(checkpoint.optimizer_state_dict)
+        if checkpoint.optimizer_scheduler_state_dict:
+            self.optimizer_scheduler.load_state_dict(checkpoint.optimizer_scheduler_state_dict)
         self.start_epoch = checkpoint.epoch
 
     def load_from_checkpoint(self, path):

--- a/egg/zoo/simple_autoenc/train.py
+++ b/egg/zoo/simple_autoenc/train.py
@@ -100,8 +100,10 @@ def main(params):
         {'params': game.sender.parameters(), 'lr': opts.sender_lr},
         {'params': game.receiver.parameters(), 'lr': opts.receiver_lr}
     ])
+    lmbda = lambda epoch: 0.95
+    scheduler = torch.optim.lr_scheduler.MultiplicativeLR(optimizer, lr_lambda=lmbda)
 
-    trainer = core.Trainer(game=game, optimizer=optimizer, train_data=train_loader,
+    trainer = core.Trainer(game=game, optimizer=optimizer, optimizer_scheduler=scheduler, train_data=train_loader,
                            validation_data=test_loader,
                            callbacks=callbacks + [core.ConsoleLogger(as_json=True)])
     trainer.train(n_epochs=opts.n_epochs)


### PR DESCRIPTION
Adding support for oprimizer adaptive lr within trainer

## Description
Added optimizer scheduler to trainer. Added it to the simple_autoenc game and will remove it from there if the PR is positively reviewed.

## Motivation and Context
Adaptive lr can be useful in various training setups. It could be also implemented as callback and accessing the optimizer state from there (each callback gets a reference to the trainer from the parent class when calling `on_train_begin`.

## How Has This Been Tested?
Implemented a multiplicative scheduler in simpler_autoenc and launched
`python -m egg.zoo.simple_autoenc.train --vocab_size=3 --n_features=6 --n_epoch=2 --max_len=3 --batch_size=32 --random_seed=21 --lr=1`
