### PR TITLE
fix scaling factor of REINFORCE

### DIFF
--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -555,6 +555,7 @@ class CommunicationRnnReinforce(nn.Module):
             effective_entropy_s += entropy_s[:, i] * not_eosed
             effective_log_prob_s += log_prob_s[:, i] * not_eosed
         effective_entropy_s = effective_entropy_s / message_length.float()
+        effective_log_prob_s = effective_log_prob_s / message_length.float()
 
         weighted_entropy = (
             effective_entropy_s.mean() * self.sender_entropy_coeff


### PR DESCRIPTION
This change adds the correct scaling factor to the REINFORCE estimate, aligning the loss of the sender with the loss of the receiver.

## Description

The REINFORCE estimator is based off of the policy gradient theorem that says 
<img src="https://render.githubusercontent.com/render/math?math=\nabla J(\theta) \propto \sum_s \mu_s \sum_a q_\pi(s,a) \nabla \pi(a|s,\theta)">

And from there we do a monte-carlo estimate to get the REINFORCE estimator
<img src="https://render.githubusercontent.com/render/math?math=\=\mathbb{E}_\pi \big\lbrack  \sum_a q_\pi(S_t,a) \nabla \pi(a|S_t,\theta) \big\rbrack">

But what is important to note is the scale of the proportionality in the policy gradient equation. The scale is equivalent to the length of the episode for a finite-length MDP (Sutton and Barto, 2018). In the case of emergent communication, the length of the episode corresponds to the length of the message. Since we divide the receiver's loss by the output length (in using the `.mean()`) we should also divide the sender's loss by its message length to ensure the same scale of gradient. 

## Related Issue (if any)


## Motivation and Context
From a theoretical perspective, this should align the magnitude of the gradients for the sender and the receiver when using variable length messages and a REINFORCE estimator.

## How Has This Been Tested?
I haven't run any tests yet. I would be interested in hearing suggestions about which zoo/paper experiments I should replicate with the correction to see if I get different/better results. 
