### PR TITLE
add support for custom batches [WIP]

### DIFF
--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -27,7 +27,7 @@ from .gs_wrappers import (
     SymbolGameGS,
     SymbolReceiverWrapper,
 )
-from .interaction import Interaction, LoggingStrategy
+from .interaction import Interaction, LoggingStrategy, dump_interactions
 from .language_analysis import (
     Disent,
     MessageEntropy,
@@ -53,7 +53,6 @@ from .trainers import Trainer
 from .util import (
     build_optimizer,
     close,
-    dump_interactions,
     find_lengths,
     get_opts,
     get_summary_writer,

--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -11,6 +11,7 @@ from .callbacks import (
     ProgressBarLogger,
     TemperatureUpdater,
     TensorboardLogger,
+    WandbLogger,
 )
 from .continous_communication import (
     ContinuousLinearReceiver,
@@ -112,4 +113,5 @@ __all__ = [
     "ContinuousLinearSender",
     "ContinuousLinearReceiver",
     "SenderReceiverContinuousCommunication",
+    "WandbLogger",
 ]

--- a/egg/core/__init__.py
+++ b/egg/core/__init__.py
@@ -11,7 +11,6 @@ from .callbacks import (
     ProgressBarLogger,
     TemperatureUpdater,
     TensorboardLogger,
-    WandbLogger,
 )
 from .continous_communication import (
     ContinuousLinearReceiver,
@@ -113,5 +112,4 @@ __all__ = [
     "ContinuousLinearSender",
     "ContinuousLinearReceiver",
     "SenderReceiverContinuousCommunication",
-    "WandbLogger",
 ]

--- a/egg/core/batch.py
+++ b/egg/core/batch.py
@@ -1,0 +1,69 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
+
+import torch
+
+from egg.core.util import move_to
+
+
+@dataclass(repr=True, unsafe_hash=True)
+class Batch:
+    sender_input: torch.Tensor
+    labels: Optional[torch.Tensor] = None
+    receiver_input: Optional[torch.Tensor] = None
+    aux: Optional[Dict[Any, Any]] = None
+
+    def __iter__(self):
+        """
+        >>> _ = torch.manual_seed(111)
+        >>> sender_input = torch.rand(2, 2)
+        >>> labels = torch.rand(2, 2)
+        >>> batch = Batch(sender_input, labels)
+        >>> it = batch.__iter__()
+        >>> it_sender_input = next(it)
+        >>> torch.allclose(sender_input, it_sender_input)
+        True
+        >>> it_labels = next(it)
+        >>> torch.allclose(labels, it_labels)
+        True
+        """
+        return iter([self.sender_input, self.labels, self.receiver_input, self.aux])
+
+
+def generate_batch_from_raw(raw_batch: Iterable) -> Batch:
+    """
+    >>> _ = torch.manual_seed(111)
+    >>> raw_batch = (torch.rand(2, 2), torch.rand(2, 2), torch.rand(2, 2), None)
+    >>> generate_batch_from_raw(raw_batch)
+    Batch(sender_input=tensor([[0.7156, 0.9140],
+            [0.2819, 0.2581]]), labels=tensor([[0.6311, 0.6001],
+            [0.9312, 0.2153]]), receiver_input=tensor([[0.6033, 0.7328],
+            [0.1857, 0.5101]]), aux=None)
+    >>> raw_batch = (torch.rand(2, 2))
+    >>> generate_batch_from_raw(raw_batch)
+    Batch(sender_input=tensor([[0.7545, 0.2884],
+            [0.5775, 0.0358]]), labels=None, receiver_input=None, aux=None)
+    """
+    if isinstance(raw_batch, torch.Tensor):
+        return Batch(sender_input=raw_batch)
+    return Batch(*raw_batch)
+
+
+def generate_identity_batch(raw_batch: Batch) -> Batch:
+    return raw_batch
+
+
+def move_batch_to(batch: Batch, device: torch.device) -> Batch:
+    """Method to move all (nested) tensors of the batch to a specific device.
+    This operation doest not change the original batch element and returns a new Batch instance.
+    """
+    moved_batch = move_to(
+        [batch.sender_input, batch.labels, batch.receiver_input, batch.aux], device
+    )
+    return Batch(*moved_batch)

--- a/egg/core/batch.py
+++ b/egg/core/batch.py
@@ -24,6 +24,33 @@ class Batch:
         self.receiver_input = receiver_input
         self.aux_input = aux_input
 
+    def __getitem__(self, idx):
+        """
+        >>> b = Batch(torch.Tensor([1]), torch.Tensor([2]), torch.Tensor([3]), {})
+        >>> b[0]
+        tensor([1.])
+        >>> b[1]
+        tensor([2.])
+        >>> b[2]
+        tensor([3.])
+        >>> b[3]
+        {}
+        >>> b[6]
+        Traceback (most recent call last):
+            ...
+        IndexError: Trying to access a wrong index in the batch
+        """
+        if idx == 0:
+            return self.sender_input
+        elif idx == 1:
+            return self.labels
+        elif idx == 2:
+            return self.receiver_input
+        elif idx == 3:
+            return self.aux_input
+        else:
+            raise IndexError("Trying to access a wrong index in the batch")
+
     def __iter__(self):
         """
         >>> _ = torch.manual_seed(111)

--- a/egg/core/batch.py
+++ b/egg/core/batch.py
@@ -46,7 +46,8 @@ class Batch:
         """Method to move all (nested) tensors of the batch to a specific device.
         This operation doest not change the original batch element and returns a new Batch instance.
         """
-        moved_batch = move_to(
-            [self.sender_input, self.labels, self.receiver_input, self.aux], device
-        )
-        return Batch(*moved_batch)
+        self.sender_input = move_to(self.sender_input, device)
+        self.labels = move_to(self.labels, device)
+        self.receiver_input = move_to(self.receiver_input, device)
+        self.aux_input = move_to(self.aux_input, device)
+        return self

--- a/egg/core/continous_communication.py
+++ b/egg/core/continous_communication.py
@@ -43,7 +43,7 @@ class ContinuousLinearSender(nn.Module):
             [nn.Linear(*dimensions) for dimensions in encoder_layer_dimensions]
         )
 
-    def forward(self, x):
+    def forward(self, x, aux_input=None):
         x = self.agent(x)
         for hidden_layer in self.encoder_hidden_layers[:-1]:
             x = self.activation(hidden_layer(x))
@@ -60,7 +60,7 @@ class ContinuousLinearReceiver(nn.Module):
         super(ContinuousLinearReceiver, self).__init__()
         self.agent = agent
 
-    def forward(self, message, input=None):
+    def forward(self, message, input=None, aux_input=None):
         agent_output = self.agent(message, input)
         return agent_output
 
@@ -104,12 +104,12 @@ class SenderReceiverContinuousCommunication(nn.Module):
             else test_logging_strategy
         )
 
-    def forward(self, sender_input, labels, receiver_input=None):
-        message = self.sender(sender_input)
-        receiver_output = self.receiver(message, receiver_input)
+    def forward(self, sender_input, labels, receiver_input=None, aux_input=None):
+        message = self.sender(sender_input, aux_input)
+        receiver_output = self.receiver(message, receiver_input, aux_input)
 
         loss, aux_info = self.loss(
-            sender_input, message, receiver_input, receiver_output, labels
+            sender_input, message, receiver_input, receiver_output, labels, aux_input
         )
         logging_strategy = (
             self.train_logging_strategy if self.training else self.test_logging_strategy
@@ -119,6 +119,7 @@ class SenderReceiverContinuousCommunication(nn.Module):
             sender_input=sender_input,
             receiver_input=receiver_input,
             labels=labels,
+            aux_input=aux_input,
             receiver_output=receiver_output,
             message=message.detach(),
             message_length=torch.ones(message[0].size(0)),

--- a/egg/core/continous_communication.py
+++ b/egg/core/continous_communication.py
@@ -44,7 +44,7 @@ class ContinuousLinearSender(nn.Module):
         )
 
     def forward(self, x, aux_input=None):
-        x = self.agent(x)
+        x = self.agent(x, aux_input)
         for hidden_layer in self.encoder_hidden_layers[:-1]:
             x = self.activation(hidden_layer(x))
         sender_output = self.encoder_hidden_layers[-1](x)
@@ -61,7 +61,7 @@ class ContinuousLinearReceiver(nn.Module):
         self.agent = agent
 
     def forward(self, message, input=None, aux_input=None):
-        agent_output = self.agent(message, input)
+        agent_output = self.agent(message, input, aux_input)
         return agent_output
 
 

--- a/egg/core/datasets.py
+++ b/egg/core/datasets.py
@@ -40,7 +40,7 @@ class AttributesValuesDataset:
 
         self.samples = list(
             itertools.product(*(range(1, n_values + 1) for _ in range(n_attributes)))
-        )  # noqa: E226
+        )
 
         seed = seed if seed else np.random.randint(0, 2 ** 31)
         self.seed = seed
@@ -97,10 +97,11 @@ class AttributesValuesIterator:
                 self.random_state.permutation(self.data)
             ).float()
 
-        # fmt: off
-        tnsr = [torch.Tensor(elem) for elem in self.data[self.idx:self.idx+self.batch_size]]  # noqa: E226
-        self.idx += (self.batch_size - 1)
-        # fmt: on
+        tnsr = [
+            torch.Tensor(elem)
+            for elem in self.data[self.idx : self.idx + self.batch_size]
+        ]
+        self.idx += self.batch_size - 1
         batch = torch.stack(tnsr)
         labels = torch.zeros(1)
 

--- a/egg/core/distributed.py
+++ b/egg/core/distributed.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import torch.distributed as dist
 
 
-@dataclass
+@dataclass(frozen=True, repr=True, eq=True, unsafe_hash=True)
 class DistributedContext:
     is_distributed: bool
     rank: int

--- a/egg/core/gs_wrappers.py
+++ b/egg/core/gs_wrappers.py
@@ -117,14 +117,18 @@ class SymbolGameGS(nn.Module):
     """
     Implements one-symbol Sender/Receiver game. The loss must be differentiable wrt the parameters of the agents.
     Typically, this assumes Gumbel Softmax relaxation of the communication channel.
+    >>> class Sender(nn.Module):
+    ...     def __init__(self):
+    ...         super().__init__()
+    ...         self.fc_out = nn.Sequential(nn.Linear(10, 10), nn.LogSoftmax(dim=1))
+    ...     def forward(self, x, _aux_input=None):
+    ...         return self.fc_out(x)
+    >>> sender = Sender()
     >>> class Receiver(nn.Module):
-    ...     def forward(self, x, _input=None):
+    ...     def forward(self, x, _input=None, _aux_input=None):
     ...         return x
-
     >>> receiver = Receiver()
-    >>> sender = nn.Sequential(nn.Linear(10, 10), nn.LogSoftmax(dim=1))
-
-    >>> def mse_loss(sender_input, _1, _2, receiver_output, _3):
+    >>> def mse_loss(sender_input, _1, _2, receiver_output, _3, _4):
     ...     return (sender_input - receiver_output).pow(2.0).mean(dim=1), {}
 
     >>> game = SymbolGameGS(sender=sender, receiver=Receiver(), loss=mse_loss)
@@ -171,12 +175,12 @@ class SymbolGameGS(nn.Module):
             else test_logging_strategy
         )
 
-    def forward(self, sender_input, labels, receiver_input=None):
-        message = self.sender(sender_input)
-        receiver_output = self.receiver(message, receiver_input)
+    def forward(self, sender_input, labels, receiver_input=None, aux_input=None):
+        message = self.sender(sender_input, aux_input)
+        receiver_output = self.receiver(message, receiver_input, aux_input)
 
         loss, aux_info = self.loss(
-            sender_input, message, receiver_input, receiver_output, labels
+            sender_input, message, receiver_input, receiver_output, labels, aux_input
         )
 
         logging_strategy = (
@@ -186,6 +190,7 @@ class SymbolGameGS(nn.Module):
             sender_input=sender_input,
             receiver_input=receiver_input,
             labels=labels,
+            aux_input=aux_input,
             receiver_output=receiver_output.detach(),
             message=message.detach(),
             message_length=torch.ones(message.size(0)),
@@ -249,9 +254,9 @@ class SymbolReceiverWrapper(nn.Module):
         self.agent = agent
         self.embedding = RelaxedEmbedding(vocab_size, agent_input_size)
 
-    def forward(self, message, input=None):
+    def forward(self, message, input=None, aux_input=None):
         embedded_message = self.embedding(message)
-        return self.agent(embedded_message, input)
+        return self.agent(embedded_message, input, aux_input)
 
 
 class RnnSenderGS(nn.Module):
@@ -262,7 +267,13 @@ class RnnSenderGS(nn.Module):
     is supposed to be handled by the game implementation. Supports vanilla RNN ('rnn'), GRU ('gru'), and LSTM ('lstm')
     cells.
 
-    >>> agent = nn.Linear(10, 5) #  input size 10, the RNN's hidden size is 5
+    >>> class Sender(nn.Module):
+    ...     def __init__(self):
+    ...         super().__init__()
+    ...         self.fc_out = nn.Linear(10, 5) #  input size 10, the RNN's hidden size is 5
+    ...     def forward(self, x, _aux_input=None):
+    ...         return self.fc_out(x)
+    >>> agent = Sender()
     >>> agent = RnnSenderGS(agent, vocab_size=2, embed_dim=10, hidden_size=5, max_len=3, temperature=1.0, cell='lstm')
     >>> output = agent(torch.ones((1, 10)))
     >>> output.size()  # batch size x max_len+1 x vocab_size
@@ -319,8 +330,8 @@ class RnnSenderGS(nn.Module):
     def reset_parameters(self):
         nn.init.normal_(self.sos_embedding, 0.0, 0.01)
 
-    def forward(self, x):
-        prev_hidden = self.agent(x)
+    def forward(self, x, aux_input=None):
+        prev_hidden = self.agent(x, aux_input)
         prev_c = torch.zeros_like(prev_hidden)  # only for LSTM
 
         e_t = torch.stack([self.sos_embedding] * prev_hidden.size(0))
@@ -376,7 +387,7 @@ class RnnReceiverGS(nn.Module):
 
         self.embedding = nn.Linear(vocab_size, embed_dim)
 
-    def forward(self, message, input=None):
+    def forward(self, message, input=None, aux_input=None):
         outputs = []
 
         emb = self.embedding(message)
@@ -396,7 +407,7 @@ class RnnReceiverGS(nn.Module):
             else:
                 h_t = self.cell(e_t, prev_hidden)
 
-            outputs.append(self.agent(h_t, input))
+            outputs.append(self.agent(h_t, input, aux_input))
             prev_hidden = h_t
 
         outputs = torch.stack(outputs).permute(1, 0, 2)
@@ -411,17 +422,21 @@ class SenderReceiverRnnGS(nn.Module):
     to the end-of-sequence symbol. It is assumed that communication is stopped either after all the message is processed
     or when the end-of-sequence symbol is met.
 
-    >>> sender = nn.Linear(10, 5)
+    >>> class Sender(nn.Module):
+    ...     def __init__(self):
+    ...         super().__init__()
+    ...         self.fc = nn.Linear(10, 5)
+    ...     def forward(self, x, _input=None, aux_input=None):
+    ...         return self.fc(x)
+    >>> sender = Sender()
     >>> sender = RnnSenderGS(sender, vocab_size=2, embed_dim=3, hidden_size=5, max_len=3, temperature=5.0, cell='gru')
-
     >>> class Receiver(nn.Module):
     ...     def __init__(self):
     ...         super().__init__()
     ...         self.fc = nn.Linear(7, 10)
-    ...     def forward(self, x, _input):
+    ...     def forward(self, x, _input=None, aux_input=None):
     ...         return self.fc(x)
     >>> receiver = RnnReceiverGS(Receiver(), vocab_size=2, embed_dim=4, hidden_size=7, cell='rnn')
-
     >>> def loss(sender_input, _message, _receiver_input, receiver_output, labels):
     ...     return (sender_input - receiver_output).pow(2.0).mean(dim=1), {'aux': torch.zeros(sender_input.size(0))}
     >>> game = SenderReceiverRnnGS(sender, receiver, loss)
@@ -474,9 +489,9 @@ class SenderReceiverRnnGS(nn.Module):
             else test_logging_strategy
         )
 
-    def forward(self, sender_input, labels, receiver_input=None):
-        message = self.sender(sender_input)
-        receiver_output = self.receiver(message, receiver_input)
+    def forward(self, sender_input, labels, receiver_input=None, aux_input=None):
+        message = self.sender(sender_input, aux_input)
+        receiver_output = self.receiver(message, receiver_input, aux_input)
 
         loss = 0
         not_eosed_before = torch.ones(receiver_output.size(0)).to(
@@ -530,6 +545,7 @@ class SenderReceiverRnnGS(nn.Module):
             sender_input=sender_input,
             receiver_input=receiver_input,
             labels=labels,
+            aux_input=aux_input,
             receiver_output=receiver_output.detach(),
             message=message.detach(),
             message_length=expected_length.detach(),

--- a/egg/core/gs_wrappers.py
+++ b/egg/core/gs_wrappers.py
@@ -437,7 +437,7 @@ class SenderReceiverRnnGS(nn.Module):
     ...     def forward(self, x, _input=None, aux_input=None):
     ...         return self.fc(x)
     >>> receiver = RnnReceiverGS(Receiver(), vocab_size=2, embed_dim=4, hidden_size=7, cell='rnn')
-    >>> def loss(sender_input, _message, _receiver_input, receiver_output, labels):
+    >>> def loss(sender_input, _message, _receiver_input, receiver_output, labels, aux_input):
     ...     return (sender_input - receiver_output).pow(2.0).mean(dim=1), {'aux': torch.zeros(sender_input.size(0))}
     >>> game = SenderReceiverRnnGS(sender, receiver, loss)
     >>> loss, interaction = game(torch.ones((3, 10)), None, None)  # batch of 3 10d vectors
@@ -508,6 +508,7 @@ class SenderReceiverRnnGS(nn.Module):
                 receiver_input,
                 receiver_output[:, step, ...],
                 labels,
+                aux_input,
             )
             eos_mask = message[:, step, 0]  # always eos == 0
 

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -15,6 +15,7 @@ class LoggingStrategy:
     store_sender_input: bool = True
     store_receiver_input: bool = True
     store_labels: bool = True
+    store_aux_input: bool = True
     store_message: bool = True
     store_receiver_output: bool = True
     store_message_length: bool = True
@@ -24,6 +25,7 @@ class LoggingStrategy:
         sender_input: Optional[torch.Tensor],
         receiver_input: Optional[torch.Tensor],
         labels: Optional[torch.Tensor],
+        aux_input: Optional[Dict[str, torch.Tensor]],
         message: Optional[torch.Tensor],
         receiver_output: Optional[torch.Tensor],
         message_length: Optional[torch.Tensor],
@@ -34,6 +36,7 @@ class LoggingStrategy:
             sender_input=sender_input if self.store_sender_input else None,
             receiver_input=receiver_input if self.store_receiver_input else None,
             labels=labels if self.store_labels else None,
+            aux_input=aux_input if self.store_aux_input else None,
             message=message if self.store_message else None,
             receiver_output=receiver_output if self.store_receiver_output else None,
             message_length=message_length if self.store_message_length else None,
@@ -42,7 +45,7 @@ class LoggingStrategy:
 
     @classmethod
     def minimal(cls):
-        args = [False] * 5 + [True]
+        args = [False] * 6 + [True]
         return cls(*args)
 
     @classmethod
@@ -56,6 +59,7 @@ class Interaction:
     sender_input: Optional[torch.Tensor]
     receiver_input: Optional[torch.Tensor]
     labels: Optional[torch.Tensor]
+    aux_input: Optional[Dict[str, torch.Tensor]]
 
     # what agents produce
     message: Optional[torch.Tensor]
@@ -96,6 +100,8 @@ class Interaction:
         self.receiver_output = _to(self.receiver_output)
         self.message_length = _to(self.message_length)
 
+        if self.aux_input:
+            self.aux_input = dict((k, _to(v)) for k, v in self.aux_input.items())
         if self.aux:
             self.aux = dict((k, _to(v)) for k, v in self.aux.items())
 
@@ -104,16 +110,16 @@ class Interaction:
     @staticmethod
     def from_iterable(interactions: Iterable["Interaction"]) -> "Interaction":
         """
-        >>> a = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
+        >>> a = Interaction(torch.ones(1), None, None, {}, torch.ones(1), torch.ones(1), None, {})
         >>> a.size
         1
-        >>> b = Interaction(torch.ones(1), None, None, torch.ones(1), torch.ones(1), None, {})
+        >>> b = Interaction(torch.ones(1), None, None, {}, torch.ones(1), torch.ones(1), None, {})
         >>> c = Interaction.from_iterable((a, b))
         >>> c.size
         2
         >>> c
         Interaction(sender_input=tensor([1., 1.]), ..., receiver_output=tensor([1., 1.]), message_length=None, aux={})
-        >>> d = Interaction(torch.ones(1), torch.ones(1), None, torch.ones(1), torch.ones(1), None, {})
+        >>> d = Interaction(torch.ones(1), torch.ones(1), None, {}, torch.ones(1), torch.ones(1), None, {})
         >>> _ = Interaction.from_iterable((a, d)) # mishaped, should throw an exception
         Traceback (most recent call last):
         ...
@@ -133,7 +139,13 @@ class Interaction:
 
         assert interactions, "list must not be empty"
         assert all(len(x.aux) == len(interactions[0].aux) for x in interactions)
+        assert all(
+            len(x.aux_input) == len(interactions[0].aux_input) for x in interactions
+        )
 
+        aux_input = {}
+        for k in interactions[0].aux_input:
+            aux_input[k] = _check_cat([x.aux_input[k] for x in interactions])
         aux = {}
         for k in interactions[0].aux:
             aux[k] = _check_cat([x.aux[k] for x in interactions])
@@ -142,6 +154,7 @@ class Interaction:
             sender_input=_check_cat([x.sender_input for x in interactions]),
             receiver_input=_check_cat([x.receiver_input for x in interactions]),
             labels=_check_cat([x.labels for x in interactions]),
+            aux_input=aux_input,
             message=_check_cat([x.message for x in interactions]),
             message_length=_check_cat([x.message_length for x in interactions]),
             receiver_output=_check_cat([x.receiver_output for x in interactions]),
@@ -150,7 +163,7 @@ class Interaction:
 
     @staticmethod
     def empty() -> "Interaction":
-        return Interaction(None, None, None, None, None, None, {})
+        return Interaction(None, None, None, {}, None, None, None, {})
 
     @staticmethod
     def gather_distributed_interactions(log: "Interaction") -> Optional["Interaction"]:
@@ -190,8 +203,13 @@ class Interaction:
         )
 
         interaction_as_dict = send_collect_dict(interaction_as_dict)
+
+        synced_aux_input = send_collect_dict(log.aux_input)
+        interaction_as_dict["aux_input"] = synced_aux_input
         synced_aux = send_collect_dict(log.aux)
         interaction_as_dict["aux"] = synced_aux
+
         synced_interacton = Interaction(**interaction_as_dict)
+
         assert log.size * world_size == synced_interacton.size
         return synced_interacton

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -137,15 +137,24 @@ class Interaction:
                 )
             return torch.cat(lst, dim=0)
 
-        assert interactions, "list must not be empty"
-        assert all(len(x.aux) == len(interactions[0].aux) for x in interactions)
-        assert all(
-            len(x.aux_input) == len(interactions[0].aux_input) for x in interactions
-        )
+        assert interactions, "interaction list must not be empty"
+        has_aux_input = interactions[0].aux_input is not None
+        for x in interactions:
+            assert len(x.aux) == len(interactions[0].aux)
+            if has_aux_input:
+                assert len(x.aux_input) == len(
+                    interactions[0].aux_input
+                ), "found two interactions of different aux_info size"
+            else:
+                assert (
+                    not x.aux_input
+                ), "some aux_info are defined some are not, this should not happen"
 
-        aux_input = {}
-        for k in interactions[0].aux_input:
-            aux_input[k] = _check_cat([x.aux_input[k] for x in interactions])
+        aux_input = None
+        if has_aux_input:
+            aux_input = {}
+            for k in interactions[0].aux_input:
+                aux_input[k] = _check_cat([x.aux_input[k] for x in interactions])
         aux = {}
         for k in interactions[0].aux:
             aux[k] = _check_cat([x.aux[k] for x in interactions])

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -10,7 +10,7 @@ import torch
 import torch.distributed as distrib
 
 
-@dataclass
+@dataclass(repr=True, eq=True)
 class LoggingStrategy:
     store_sender_input: bool = True
     store_receiver_input: bool = True
@@ -50,7 +50,7 @@ class LoggingStrategy:
         return cls()
 
 
-@dataclass
+@dataclass(repr=True, unsafe_hash=True)
 class Interaction:
     # incoming data
     sender_input: Optional[torch.Tensor]
@@ -112,7 +112,7 @@ class Interaction:
         >>> c.size
         2
         >>> c
-        Interaction(sender_input=tensor([1., 1.]), receiver_input=None, labels=None, message=tensor([1., 1.]), receiver_output=tensor([1., 1.]), message_length=None, aux={})
+        Interaction(sender_input=tensor([1., 1.]), ..., receiver_output=tensor([1., 1.]), message_length=None, aux={})
         >>> d = Interaction(torch.ones(1), torch.ones(1), None, torch.ones(1), torch.ones(1), None, {})
         >>> _ = Interaction.from_iterable((a, d)) # mishaped, should throw an exception
         Traceback (most recent call last):

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -9,6 +9,8 @@ from typing import Dict, Iterable, Optional
 import torch
 import torch.distributed as distrib
 
+from egg.core.batch import Batch
+
 
 @dataclass(repr=True, eq=True)
 class LoggingStrategy:
@@ -222,3 +224,58 @@ class Interaction:
 
         assert log.size * world_size == synced_interacton.size
         return synced_interacton
+
+
+def dump_interactions(
+    game: torch.nn.Module,
+    dataset: "torch.utils.data.DataLoader",
+    gs: bool,
+    variable_length: bool,
+    device: Optional[torch.device] = None,
+    apply_padding: bool = True,
+) -> Interaction:
+    """
+    A tool to dump the interaction between Sender and Receiver
+    :param game: A Game instance
+    :param dataset: Dataset of inputs to be used when analyzing the communication
+    :param gs: whether the messages should be argmaxed over the last dimension.
+        Handy, if Gumbel-Softmax relaxation was used for training.
+    :param variable_length: whether variable-length communication is used.
+    :param device: device (e.g. 'cuda') to be used.
+    :return: The entire log of agent interactions, represented as an Interaction instance.
+    """
+    train_state = game.training  # persist so we restore it back
+    game.eval()
+    device = (
+        device
+        if device is not None
+        else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    full_interaction = None
+
+    with torch.no_grad():
+        for batch in dataset:
+            if not isinstance(batch, Batch):
+                batch = Batch(*batch)
+            batch = batch.to(device)
+            _, interaction = game(*batch)
+            interaction = interaction.to("cpu")
+
+            if gs:
+                interaction.message = interaction.message.argmax(
+                    dim=-1
+                )  # actual symbols instead of one-hot encoded
+            if apply_padding and variable_length:
+                assert interaction.message_length is not None
+                for i in range(interaction.size):
+                    length = interaction.message_length[i].long().item()
+                    interaction.message[i, length:] = 0  # 0 is always EOS
+
+            full_interaction = (
+                full_interaction + interaction
+                if full_interaction is not None
+                else interaction
+            )
+
+    game.train(mode=train_state)
+    return interaction

--- a/egg/core/losses.py
+++ b/egg/core/losses.py
@@ -11,7 +11,13 @@ import torch.nn.functional as F
 
 class DiscriminationLoss:
     def __call__(
-        self, sender_input, _message, _receiver_input, receiver_output, labels
+        self,
+        sender_input,
+        _message,
+        _receiver_input,
+        receiver_output,
+        labels,
+        _aux_input,
     ):
         return self.discrimination_loss(receiver_output, labels)
 
@@ -29,7 +35,13 @@ class ReconstructionLoss:
         self.batch_size = batch_size
 
     def __call__(
-        self, sender_input, _message, _receiver_input, receiver_output, labels
+        self,
+        sender_input,
+        _message,
+        _receiver_input,
+        receiver_output,
+        labels,
+        _aux_input,
     ):
         return self.reconstruction_loss(
             receiver_output, labels, self.batch_size, self.n_attributes, self.n_values
@@ -143,7 +155,13 @@ class NTXentLoss:
         return loss, {"acc": acc}
 
     def __call__(
-        self, _sender_input, message, _receiver_input, receiver_output, _labels
+        self,
+        _sender_input,
+        message,
+        _receiver_input,
+        receiver_output,
+        _labels,
+        _aux_input,
     ):
         return self.ntxent_loss(
             message,

--- a/egg/core/losses.py
+++ b/egg/core/losses.py
@@ -76,7 +76,7 @@ class NTXentLoss:
     >>> x_i = torch.eye(128)
     >>> x_j = torch.eye(128)
     >>> loss_fn = NTXentLoss()
-    >>> loss, aux = loss_fn(None, x_i, None, x_j, None)
+    >>> loss, aux = loss_fn(None, x_i, None, x_j, None, None)
     >>> aux["acc"].mean().item()
     1.0
     >>> aux["acc"].shape

--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -187,11 +187,11 @@ class SymbolGameReinforce(nn.Module):
         policy_loss = (
             (loss.detach() - self.baseline.predict(loss.detach()))
             * (sender_log_prob + receiver_log_prob)
-        ).mean()  # noqa: E502
+        ).mean()
         entropy_loss = -(
             sender_entropy.mean() * self.sender_entropy_coeff
             + receiver_entropy.mean() * self.receiver_entropy_coeff
-        )  # noqa: E502
+        )
 
         if self.training:
             self.baseline.update(loss.detach())

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -171,7 +171,7 @@ class Trainer:
             for batch in self.validation_data:
                 if not isinstance(batch, Batch):
                     batch = Batch(*batch)
-                batch.to(self.device)
+                batch = batch.to(self.device)
                 optimized_loss, interaction = self.game(*batch)
                 if (
                     self.distributed_context.is_distributed

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -5,7 +5,7 @@
 
 import os
 import pathlib
-from typing import Any, Callable, List, Optional
+from typing import List, Optional
 
 try:
     # requires python >= 3.7
@@ -17,7 +17,7 @@ except ImportError:
 import torch
 from torch.utils.data import DataLoader
 
-from .batch import Batch, generate_batch_from_raw, move_batch_to
+from .batch import Batch
 from .callbacks import (
     Callback,
     Checkpoint,
@@ -52,7 +52,6 @@ class Trainer:
         callbacks: Optional[List[Callback]] = None,
         grad_norm: float = None,
         aggregate_interaction_logs: bool = True,
-        generate_batch_fn: Callable[[Any], Batch] = generate_batch_from_raw,
     ):
         """
         :param game: A nn.Module that implements forward(); it is expected that forward returns a tuple of (loss, d),
@@ -73,7 +72,6 @@ class Trainer:
         common_opts = get_opts()
         self.validation_freq = common_opts.validation_freq
         self.device = common_opts.device if device is None else device
-        self.generate_batch_fn = generate_batch_fn
 
         self.should_stop = False
         self.start_epoch = 0  # Can be overwritten by checkpoint loader
@@ -171,8 +169,9 @@ class Trainer:
         self.game.eval()
         with torch.no_grad():
             for batch in self.validation_data:
-                batch = self.generate_batch_fn(batch)
-                batch = move_batch_to(batch, self.device)
+                if not isinstance(batch, Batch):
+                    batch = Batch(*batch)
+                batch.to(self.device)
                 optimized_loss, interaction = self.game(*batch)
                 if (
                     self.distributed_context.is_distributed
@@ -207,8 +206,9 @@ class Trainer:
         self.optimizer.zero_grad()
 
         for batch_id, batch in enumerate(self.train_data):
-            batch = self.generate_batch_fn(batch)
-            batch = move_batch_to(batch, self.device)
+            if not isinstance(batch, Batch):
+                batch = Batch(*batch)
+            batch.to(self.device)
 
             context = autocast() if self.scaler else nullcontext()
             with context:

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -208,7 +208,7 @@ class Trainer:
         for batch_id, batch in enumerate(self.train_data):
             if not isinstance(batch, Batch):
                 batch = Batch(*batch)
-            batch.to(self.device)
+            batch = batch.to(self.device)
 
             context = autocast() if self.scaler else nullcontext()
             with context:

--- a/egg/core/util.py
+++ b/egg/core/util.py
@@ -14,7 +14,6 @@ import numpy as np
 import torch
 
 from .distributed import maybe_init_distributed
-from .interaction import Interaction
 
 common_opts = None
 optimizer = None
@@ -253,55 +252,6 @@ def _set_seed(seed) -> None:
     np.random.seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
-
-
-def dump_interactions(
-    game: torch.nn.Module,
-    dataset: "torch.utils.data.DataLoader",
-    gs: bool,
-    variable_length: bool,
-    device: Optional[torch.device] = None,
-    apply_padding: bool = True,
-) -> Interaction:
-    """
-    A tool to dump the interaction between Sender and Receiver
-    :param game: A Game instance
-    :param dataset: Dataset of inputs to be used when analyzing the communication
-    :param gs: whether the messages should be argmaxed over the last dimension.
-        Handy, if Gumbel-Softmax relaxation was used for training.
-    :param variable_length: whether variable-length communication is used.
-    :param device: device (e.g. 'cuda') to be used.
-    :return: The entire log of agent interactions, represented as an Interaction instance.
-    """
-    train_state = game.training  # persist so we restore it back
-    game.eval()
-    device = device if device is not None else common_opts.device
-    full_interaction = None
-
-    with torch.no_grad():
-        for batch in dataset:
-            batch = move_to(batch, device)
-            _, interaction = game(*batch)
-            interaction = interaction.to("cpu")
-
-            if gs:
-                interaction.message = interaction.message.argmax(
-                    dim=-1
-                )  # actual symbols instead of one-hot encoded
-            if apply_padding and variable_length:
-                assert interaction.message_length is not None
-                for i in range(interaction.size):
-                    length = interaction.message_length[i].long().item()
-                    interaction.message[i, length:] = 0  # 0 is always EOS
-
-            full_interaction = (
-                full_interaction + interaction
-                if full_interaction is not None
-                else interaction
-            )
-
-    game.train(mode=train_state)
-    return interaction
 
 
 def move_to(x: Any, device: torch.device) -> Any:

--- a/egg/zoo/basic_games/architectures.py
+++ b/egg/zoo/basic_games/architectures.py
@@ -22,7 +22,7 @@ class RecoReceiver(nn.Module):
         super(RecoReceiver, self).__init__()
         self.output = nn.Linear(n_hidden, n_features)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input):
         return self.output(x)
 
 
@@ -36,7 +36,7 @@ class DiscriReceiver(nn.Module):
         super(DiscriReceiver, self).__init__()
         self.fc1 = nn.Linear(n_features, n_hidden)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input):
         # the rationale for the non-linearity here is that the RNN output will also be the outcome of a non-linearity
         embedded_input = self.fc1(_input).tanh()
         dots = torch.matmul(embedded_input, torch.unsqueeze(x, dim=-1))
@@ -50,6 +50,6 @@ class Sender(nn.Module):
         super(Sender, self).__init__()
         self.fc1 = nn.Linear(n_features, n_hidden)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         return self.fc1(x)
         # here, it might make sense to add a non-linearity, such as tanh

--- a/egg/zoo/basic_games/play.py
+++ b/egg/zoo/basic_games/play.py
@@ -132,7 +132,14 @@ def main(params):
         # the game object we will encounter below takes as one of its mandatory arguments a loss: a loss in EGG is expected to take as arguments the sender input,
         # the message, the Receiver input, the Receiver output and the labels (although some of these elements might not actually be used by a particular loss);
         # together with the actual loss computation, the loss function can return a dictionary with other auxiliary statistics: in this case, accuracy
-        def loss(_sender_input, _message, _receiver_input, receiver_output, labels):
+        def loss(
+            _sender_input,
+            _message,
+            _receiver_input,
+            receiver_output,
+            labels,
+            _aux_input,
+        ):
             # in the discriminative case, accuracy is computed by comparing the index with highest score in Receiver output (a distribution of unnormalized
             # probabilities over target poisitions) and the corresponding label read from input, indicating the ground-truth position of the target
             acc = (receiver_output.argmax(dim=1) == labels).detach().float()
@@ -166,7 +173,9 @@ def main(params):
 
     else:  # reco game
 
-        def loss(sender_input, _message, _receiver_input, receiver_output, labels):
+        def loss(
+            sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
+        ):
             # in the case of the recognition game, for each attribute we compute a different cross-entropy score
             # based on comparing the probability distribution produced by the Receiver over the values of each attribute
             # with the corresponding ground truth, and then averaging across attributes

--- a/egg/zoo/channel/archs.py
+++ b/egg/zoo/channel/archs.py
@@ -11,7 +11,7 @@ class Receiver(nn.Module):
         super(Receiver, self).__init__()
         self.output = nn.Linear(n_hidden, n_features)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input):
         return self.output(x)
 
 
@@ -20,6 +20,6 @@ class Sender(nn.Module):
         super(Sender, self).__init__()
         self.fc1 = nn.Linear(n_features, n_hidden)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         x = self.fc1(x)
         return x

--- a/egg/zoo/channel/train.py
+++ b/egg/zoo/channel/train.py
@@ -149,7 +149,7 @@ def get_params(params):
     return args
 
 
-def loss(sender_input, _message, _receiver_input, receiver_output, _labels):
+def loss(sender_input, _message, _receiver_input, receiver_output, _labels, _aux_input):
     acc = (receiver_output.argmax(dim=1) == sender_input.argmax(dim=1)).detach().float()
     loss = F.cross_entropy(
         receiver_output, sender_input.argmax(dim=1), reduction="none"

--- a/egg/zoo/compo_vs_generalization/archs.py
+++ b/egg/zoo/compo_vs_generalization/archs.py
@@ -3,15 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import random
-from collections import defaultdict
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.distributions import Bernoulli, Categorical
-
-import egg.core as core
 
 
 class Receiver(nn.Module):
@@ -19,7 +13,7 @@ class Receiver(nn.Module):
         super(Receiver, self).__init__()
         self.fc = nn.Linear(n_hidden, n_outputs)
 
-    def forward(self, x, _):
+    def forward(self, x, _input, _aux_input):
         return self.fc(x)
 
 
@@ -28,7 +22,7 @@ class Sender(nn.Module):
         super(Sender, self).__init__()
         self.fc1 = nn.Linear(n_inputs, n_hidden)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         x = self.fc1(x)
         return x
 
@@ -45,7 +39,7 @@ class NonLinearReceiver(nn.Module):
         self.diagonal_embedding = nn.Embedding(vocab_size, vocab_size)
         nn.init.eye_(self.diagonal_embedding.weight)
 
-    def forward(self, x, *rest):
+    def forward(self, x, _input, _aux_input):
         with torch.no_grad():
             x = self.diagonal_embedding(x).view(x.size(0), -1)
 

--- a/egg/zoo/compo_vs_generalization/intervention.py
+++ b/egg/zoo/compo_vs_generalization/intervention.py
@@ -11,6 +11,7 @@ from scipy import spatial
 from scipy.stats import spearmanr
 
 import egg.core as core
+from egg.core.batch import Batch
 from egg.zoo.language_bottleneck.intervention import entropy, mutual_info
 
 try:
@@ -204,8 +205,9 @@ class Evaluator(core.Callback):
 
             for batch in loader:
                 n_batches += 1
-
-                batch = core.move_to(batch, self.device)
+                if not isinstance(batch, Batch):
+                    batch = Batch(*batch)
+                batch = batch.to(self.device)
                 with torch.no_grad():
                     _, interaction = game(*batch)
                 acc += interaction.aux["acc"].mean().item()

--- a/egg/zoo/compo_vs_generalization/train.py
+++ b/egg/zoo/compo_vs_generalization/train.py
@@ -98,7 +98,13 @@ class DiffLoss(torch.nn.Module):
         self.test_generalization = generalization
 
     def forward(
-        self, sender_input, _message, _receiver_input, receiver_output, _labels
+        self,
+        sender_input,
+        _message,
+        _receiver_input,
+        receiver_output,
+        _labels,
+        _aux_input,
     ):
         batch_size = sender_input.size(0)
         sender_input = sender_input.view(batch_size, self.n_attributes, self.n_values)

--- a/egg/zoo/compositional_efficiency/archs.py
+++ b/egg/zoo/compositional_efficiency/archs.py
@@ -3,17 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import itertools
 import math
-import random
 
-import numpy as np
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-from torch.distributions import Bernoulli, Categorical
-
-import egg.core as core
 
 
 class Receiver(nn.Module):
@@ -30,7 +23,7 @@ class Receiver(nn.Module):
 
             self.net = nn.Sequential(*l)
 
-    def forward(self, x, _):
+    def forward(self, x, input, aux_input):
         x = self.net(x)
         return x
 
@@ -41,9 +34,7 @@ class IdentitySender(nn.Module):
         self.n_attributes = n_attributes
         self.n_values = n_values
 
-    def forward(self, x):
-        batch_size = x.size(0)
-
+    def forward(self, x, aux_input):
         message = x
         assert message.size(1) == 2
 
@@ -57,8 +48,7 @@ class RotatedSender(nn.Module):
         self.n_attributes = n_attributes
         self.n_values = n_values
 
-    def forward(self, x):
-        batch_size = x.size(0)
+    def forward(self, x, aux_input):
         message = torch.zeros_like(x).long()
 
         if x.size(1) == 2:
@@ -95,9 +85,7 @@ class CircleSender(nn.Module):
         super().__init__()
         self.vocab_size = vocab_size
 
-    def forward(self, x):
-        batch_size = x.size(0)
-
+    def forward(self, x, aux_input):
         assert (x >= -1).all() and (x <= 1).all()
         message = ((x + 1) / 2 * (self.vocab_size - 1)).round().long()
         assert (message < self.vocab_size).all()

--- a/egg/zoo/compositional_efficiency/continuous.py
+++ b/egg/zoo/compositional_efficiency/continuous.py
@@ -45,7 +45,9 @@ def get_params(params):
     return args
 
 
-def diff_loss(sender_input, _message, _receiver_input, receiver_output, _labels):
+def diff_loss(
+    sender_input, _message, _receiver_input, receiver_output, _labels, _aux_input
+):
     loss = F.mse_loss(receiver_output, sender_input, reduction="none").mean(-1)
     return loss, {}
 

--- a/egg/zoo/compositional_efficiency/discrete.py
+++ b/egg/zoo/compositional_efficiency/discrete.py
@@ -67,7 +67,13 @@ class DiffLoss(torch.nn.Module):
         self.coeffs = SMALL_PRIMES
 
     def forward(
-        self, sender_input, _message, _receiver_input, receiver_output, _labels
+        self,
+        sender_input,
+        _message,
+        _receiver_input,
+        receiver_output,
+        _labels,
+        _aux_input,
     ):
         batch_size = sender_input.size(0)
         receiver_output = receiver_output.view(

--- a/egg/zoo/dsprites_bvae/train.py
+++ b/egg/zoo/dsprites_bvae/train.py
@@ -117,7 +117,6 @@ class ImageDumpCallback(core.Callback):
         dump_dir = pathlib.Path.cwd() / "dump" / str(epoch)
         dump_dir.mkdir(exist_ok=True, parents=True)
 
-        state = self.trainer.game.train
         self.trainer.game.eval()
 
         len_dataset = len(self.eval_dataset)
@@ -144,7 +143,7 @@ class ImageDumpCallback(core.Callback):
             utils.save_image(
                 torch.cat([image, output], dim=1), dump_dir / (str(i) + ".png")
             )
-        self.trainer.game.train(state)
+        self.trainer.game.train()
 
 
 def main(params):

--- a/egg/zoo/dsprites_bvae/train.py
+++ b/egg/zoo/dsprites_bvae/train.py
@@ -17,9 +17,8 @@ from torchvision import utils
 
 import egg.core as core
 from egg.core.language_analysis import Disent, TopographicSimilarity
+from egg.zoo.dsprites_bvae.archs import VisualReceiver, VisualSender
 from egg.zoo.dsprites_bvae.data_loaders.data_loaders import get_dsprites_dataloader
-
-from .archs import VisualReceiver, VisualSender
 
 
 def reconstruction_loss(x, x_recon, distribution="bernoulli"):
@@ -98,6 +97,7 @@ class betaVAE_Game(nn.Module):
             sender_input=label,
             receiver_input=None,
             receiver_output=receiver_output.detach(),
+            aux_input=None,
             message=message.detach(),
             labels=None,
             message_length=torch.ones(message.size(0)),

--- a/egg/zoo/emcom_as_ssl/archs.py
+++ b/egg/zoo/emcom_as_ssl/archs.py
@@ -84,7 +84,7 @@ class VisionGameWrapper(nn.Module):
         self.game = game
         self.vision_module = vision_module
 
-    def forward(self, sender_input, labels, receiver_input=None):
+    def forward(self, sender_input, labels, receiver_input=None, aux_input=None):
         x_i, x_j = sender_input
         sender_encoded_input, receiver_encoded_input = self.vision_module(x_i, x_j)
 
@@ -182,7 +182,7 @@ class EmComSSLSymbolGame(SenderReceiverContinuousCommunication):
     def __init__(self, *args, **kwargs):
         super(EmComSSLSymbolGame, self).__init__(*args, **kwargs)
 
-    def forward(self, sender_input, labels, receiver_input=None):
+    def forward(self, sender_input, labels, receiver_input):
         if isinstance(self.sender, SimCLRSender):
             message, message_like, resnet_output_sender = self.sender(
                 sender_input, sender=True
@@ -215,6 +215,7 @@ class EmComSSLSymbolGame(SenderReceiverContinuousCommunication):
             sender_input=sender_input,
             receiver_input=receiver_input,
             labels=labels,
+            aux_input=None,
             receiver_output=receiver_output.detach(),
             message=message.detach(),
             message_length=torch.ones(message.size(0)),

--- a/egg/zoo/emcom_as_ssl/losses.py
+++ b/egg/zoo/emcom_as_ssl/losses.py
@@ -56,7 +56,13 @@ class XEntLoss(Loss):
         return loss, {"acc": acc, "game_acc": acc}
 
     def __call__(
-        self, _sender_input, message, _receiver_input, receiver_output, _labels
+        self,
+        _sender_input,
+        message,
+        _receiver_input,
+        receiver_output,
+        _labels,
+        _aux_input,
     ):
         assert (
             message.shape == receiver_output.shape
@@ -103,6 +109,12 @@ class NTXentLoss(Loss):
         return loss, {"acc": acc, "game_acc": game_acc}
 
     def __call__(
-        self, _sender_input, message, _receiver_input, receiver_output, _labels
+        self,
+        _sender_input,
+        message,
+        _receiver_input,
+        receiver_output,
+        _labels,
+        _aux_input,
     ):
         return self.ntxent_loss(message, receiver_output)

--- a/egg/zoo/external_game/archs.py
+++ b/egg/zoo/external_game/archs.py
@@ -12,7 +12,7 @@ class ReinforceReceiver(nn.Module):
         super(ReinforceReceiver, self).__init__()
         self.output = nn.Linear(n_hidden, output_size)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input):
         logits = self.output(x).log_softmax(dim=1)
         distr = Categorical(logits=logits)
         entropy = distr.entropy()
@@ -31,7 +31,7 @@ class Receiver(nn.Module):
         super(Receiver, self).__init__()
         self.output = nn.Linear(n_hidden, output_size)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input):
         return self.output(x)
 
 
@@ -40,6 +40,6 @@ class Sender(nn.Module):
         super(Sender, self).__init__()
         self.fc1 = nn.Linear(n_features, n_hidden)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         x = self.fc1(x)
         return x

--- a/egg/zoo/external_game/game.py
+++ b/egg/zoo/external_game/game.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import argparse
 import contextlib
-import sys
 
 import torch.nn.functional as F
 import torch.utils.data
@@ -167,7 +166,7 @@ def dump(game, dataset, device, is_gs):
 
 
 def differentiable_loss(
-    _sender_input, _message, _receiver_input, receiver_output, labels
+    _sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
 ):
     labels = labels.squeeze(1)
     acc = (receiver_output.argmax(dim=1) == labels).detach().float()
@@ -176,7 +175,7 @@ def differentiable_loss(
 
 
 def non_differentiable_loss(
-    _sender_input, _message, _receiver_input, receiver_output, labels
+    _sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
 ):
     labels = labels.squeeze(1)
     acc = (receiver_output == labels).detach().float()

--- a/egg/zoo/language_bottleneck/guess_number/archs.py
+++ b/egg/zoo/language_bottleneck/guess_number/archs.py
@@ -8,8 +8,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions import Bernoulli
 
-import egg.core as core
-
 
 class Receiver(nn.Module):
     def __init__(self, n_bits, n_hidden):
@@ -19,7 +17,7 @@ class Receiver(nn.Module):
         self.fc1 = nn.Linear(2 * n_hidden, 2 * n_hidden)
         self.fc2 = nn.Linear(2 * n_hidden, n_bits)
 
-    def forward(self, embedded_message, bits):
+    def forward(self, embedded_message, bits, _auxt_input=None):
         embedded_bits = self.emb_column(bits.float())
 
         x = torch.cat([embedded_bits, embedded_message], dim=1)
@@ -38,7 +36,7 @@ class ReinforcedReceiver(nn.Module):
         self.fc1 = nn.Linear(2 * n_hidden, 2 * n_hidden)
         self.fc2 = nn.Linear(2 * n_hidden, n_bits)
 
-    def forward(self, embedded_message, bits):
+    def forward(self, embedded_message, bits, _aux_input=None):
         embedded_bits = self.emb_column(bits.float())
 
         x = torch.cat([embedded_bits, embedded_message], dim=1)
@@ -65,7 +63,7 @@ class Sender(nn.Module):
         self.emb = nn.Linear(n_bits, n_hidden)
         self.fc = nn.Linear(n_hidden, vocab_size)
 
-    def forward(self, bits):
+    def forward(self, bits, _aux_input=None):
         x = self.emb(bits.float())
         x = F.leaky_relu(x)
         message = self.fc(x)

--- a/egg/zoo/language_bottleneck/guess_number/train.py
+++ b/egg/zoo/language_bottleneck/guess_number/train.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import json
 
 import torch.nn.functional as F
 import torch.utils.data
@@ -120,7 +119,9 @@ def get_params(params):
     return args
 
 
-def diff_loss(_sender_input, _message, _receiver_input, receiver_output, labels):
+def diff_loss(
+    _sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
+):
     acc = ((receiver_output > 0.5).long() == labels).detach().all(dim=1).float()
     loss = F.binary_cross_entropy(
         receiver_output, labels.float(), reduction="none"
@@ -128,7 +129,9 @@ def diff_loss(_sender_input, _message, _receiver_input, receiver_output, labels)
     return loss, {"acc": acc}
 
 
-def non_diff_loss(_sender_input, _message, _receiver_input, receiver_output, labels):
+def non_diff_loss(
+    _sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
+):
     acc = ((receiver_output > 0.5).long() == labels).detach().all(dim=1).float()
     return -acc, {"acc": acc.mean()}
 

--- a/egg/zoo/language_bottleneck/intervention.py
+++ b/egg/zoo/language_bottleneck/intervention.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 
 import egg.core as core
+from egg.core.batch import Batch
 
 
 def entropy_dict(freq_table):
@@ -103,14 +104,12 @@ class CallbackEvaluator(core.Callback):
         alice_inputs = []
 
         for batch in self.dataset:
-            batch = [x.to(self.device) for x in batch]
-            if len(batch) == 3:
-                sender_input, labels, receiver_input = batch
-            else:
-                sender_input, labels = batch
-                receiver_input = None
+            if not isinstance(batch, Batch):
+                batch = Batch(*batch)
+            batch = batch.to(self.device)
+            sender_input, labels, receiver_input, aux_input = batch
 
-            original_message = game.sender(sender_input)
+            original_message = game.sender(sender_input, aux_input)
             # if Reinforce, agents return tuples
             if not self.is_gs:
                 original_message = original_message[0]
@@ -123,13 +122,13 @@ class CallbackEvaluator(core.Callback):
                 original_message.device
             )
             message = torch.index_select(original_message, 0, permutation)
-            output = game.receiver(message, receiver_input)
+            output = game.receiver(message, receiver_input, aux_input)
 
             if not self.is_gs:
                 output = output[0]
 
             if not self.var_length:
-                _, rest = self.loss(None, None, None, output, labels)
+                _, rest = self.loss(None, None, None, output, labels, aux_input)
                 mean_acc += rest["acc"].mean().item()
                 scaler += 1
 
@@ -188,17 +187,19 @@ class CallbackEvaluator(core.Callback):
         scaler = 0.0
 
         for batch in self.dataset:
-            batch = [x.to(self.device) for x in batch]
-            sender_input, labels, receiver_input = batch
+            if not isinstance(batch, Batch):
+                batch = Batch(*batch)
+            batch = batch.to(self.device)
+            sender_input, labels, receiver_input, aux_input = batch
 
-            message = game.sender(sender_input)
+            message = game.sender(sender_input, aux_input)
             # if Reinforce, agents return tuples
             if not self.is_gs:
                 message = message[0]
 
             permutation = torch.randperm(receiver_input.size(0)).to(message.device)
             receiver_input = torch.index_select(receiver_input, 0, permutation)
-            output = game.receiver(message, receiver_input)
+            output = game.receiver(message, receiver_input, aux_input)
 
             if not self.is_gs:
                 output = output[0]
@@ -214,11 +215,12 @@ class CallbackEvaluator(core.Callback):
                         None,
                         output[i : i + 1, curr_len - 1],
                         labels[i : i + 1],
+                        aux_input,
                     )
                     mean_acc += rest["acc"].item()
                     scaler += 1
             else:
-                _, rest = self.loss(None, None, None, output, labels)
+                _, rest = self.loss(None, None, None, output, labels, aux_input)
                 mean_acc += rest["acc"].mean().item()
                 scaler += 1.0
 

--- a/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb
+++ b/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb
@@ -81,7 +81,7 @@
     "        self.fc1 = nn.Linear(784, 400)\n",
     "        self.fc2 = nn.Linear(400, vocab_size)\n",
     "\n",
-    "    def forward(self, x):\n",
+    "    def forward(self, x, aux_input=None):\n",
     "        x = x.view(-1, 784)\n",
     "        x = F.relu(self.fc1(x))\n",
     "        x = self.fc2(x)\n",
@@ -98,7 +98,7 @@
     "        \n",
     "        self.class_embedding = torch.nn.Embedding(10, 400)\n",
     "\n",
-    "    def forward(self, message, class_label):\n",
+    "    def forward(self, message, class_label, aux_input=None):\n",
     "        class_embedded = self.class_embedding(class_label)\n",
     "        message_embedded = self.fc1(message)\n",
     "\n",
@@ -111,7 +111,7 @@
     "# EGG expects the loss function to return a tuple of actually optimized loss and a dictionary of\n",
     "# 'informative' values which are averaged per-epoch and reported, but are not used for optimization\n",
     "\n",
-    "def loss(sender_input, _message, _receiver_input, receiver_output, _labels):\n",
+    "def loss(sender_input, _message, _receiver_input, receiver_output, _labels, _aux_input):\n",
     "    loss = F.binary_cross_entropy(receiver_output, sender_input.view(-1, 784), reduction='none').mean(dim=1)\n",
     "    return loss, {}"
    ]
@@ -377,7 +377,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/egg/zoo/language_bottleneck/mnist_adv/archs.py
+++ b/egg/zoo/language_bottleneck/mnist_adv/archs.py
@@ -36,7 +36,7 @@ class Sender(nn.Module):
         self.linear_channel = linear_channel
         self.softmax_channel = softmax_channel
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         x = self.vision(x)
         x = self.fc(x)
 
@@ -54,7 +54,7 @@ class Receiver(nn.Module):
         self.message_inp = core.RelaxedEmbedding(vocab_size, 400)
         self.fc = nn.Linear(400, n_classes)
 
-    def forward(self, message, _):
+    def forward(self, message, input, _aux_input):
         x = self.message_inp(message)
         x = self.fc(x)
 

--- a/egg/zoo/language_bottleneck/mnist_adv/train.py
+++ b/egg/zoo/language_bottleneck/mnist_adv/train.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import json
 
 import torch.distributions
 import torch.utils.data
@@ -18,7 +17,9 @@ from egg.zoo.language_bottleneck.mnist_classification.data import DoubleMnist
 from egg.zoo.language_bottleneck.relaxed_channel import AlwaysRelaxedWrapper
 
 
-def diff_loss_symbol(_sender_input, _message, _receiver_input, receiver_output, labels):
+def diff_loss_symbol(
+    _sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
+):
     loss = F.nll_loss(receiver_output, labels, reduction="none").mean()
     acc = (receiver_output.argmax(dim=1) == labels).float()
     return loss, {"acc": acc}

--- a/egg/zoo/language_bottleneck/mnist_classification/archs.py
+++ b/egg/zoo/language_bottleneck/mnist_classification/archs.py
@@ -34,7 +34,7 @@ class Sender(nn.Module):
         self.vision = LeNet()
         self.fc = nn.Linear(400, vocab_size)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         x = self.vision(x)
         x = self.fc(x)
         logits = F.log_softmax(x, dim=1)
@@ -60,7 +60,7 @@ class Receiver(nn.Module):
 
         self.fc = nn.Linear(400, n_classes)
 
-    def forward(self, message, image):
+    def forward(self, message, image, _aux_input):
         x = self.message_inp(message)
         if self.hidden:
             x = self.hidden(x)

--- a/egg/zoo/language_bottleneck/mnist_classification/train.py
+++ b/egg/zoo/language_bottleneck/mnist_classification/train.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import json
 
 import torch.distributions
 import torch.utils.data
@@ -18,7 +17,9 @@ from egg.zoo.language_bottleneck.mnist_classification.archs import Receiver, Sen
 from egg.zoo.language_bottleneck.mnist_classification.data import DoubleMnist
 
 
-def diff_loss_symbol(_sender_input, _message, _receiver_input, receiver_output, labels):
+def diff_loss_symbol(
+    _sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
+):
     loss = F.nll_loss(receiver_output, labels, reduction="none").mean()
     acc = (receiver_output.argmax(dim=1) == labels).float()
     return loss, {"acc": acc}

--- a/egg/zoo/language_bottleneck/mnist_overfit/archs.py
+++ b/egg/zoo/language_bottleneck/mnist_overfit/archs.py
@@ -46,7 +46,7 @@ class Sender(nn.Module):
         else:
             self.fc = nn.Linear(400, vocab_size)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         x = self.vision(x)
         if self.deeper:
             x = self.fc1(x)
@@ -72,7 +72,7 @@ class Receiver(nn.Module):
             self.fc2 = nn.Linear(400, n_classes)
         self.deeper = deeper
 
-    def forward(self, message, _):
+    def forward(self, message, _input, _aux_input):
         x = self.message_inp(message)
         if not self.deeper:
             x = self.fc(x)

--- a/egg/zoo/language_bottleneck/mnist_overfit/train.py
+++ b/egg/zoo/language_bottleneck/mnist_overfit/train.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import json
 
 import torch.distributions
 import torch.utils.data
@@ -19,7 +18,9 @@ from egg.zoo.language_bottleneck.mnist_overfit.data import corrupt_labels_
 from egg.zoo.language_bottleneck.relaxed_channel import AlwaysRelaxedWrapper
 
 
-def diff_loss_symbol(_sender_input, _message, _receiver_input, receiver_output, labels):
+def diff_loss_symbol(
+    _sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
+):
     loss = F.nll_loss(receiver_output, labels, reduction="none").mean()
     acc = (receiver_output.argmax(dim=1) == labels).float()
     return loss, {"acc": acc}

--- a/egg/zoo/mnist_autoenc/train.py
+++ b/egg/zoo/mnist_autoenc/train.py
@@ -21,7 +21,7 @@ class Sender(nn.Module):
         self.fc1 = nn.Linear(784, 400)
         self.fc2 = nn.Linear(400, vocab_size)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         x = x.view(-1, 784)
         x = F.relu(self.fc1(x))
         x = self.fc2(x)
@@ -36,7 +36,7 @@ class Receiver(nn.Module):
         super(Receiver, self).__init__()
         self.fc = nn.Linear(400, 784)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input):
         # Under GS-based optimization, the embedding layer of SymbolReceiverWrapper would be
         # essentially a linear layer. Since there is no point in having two linear layers
         # sequentially, we put a non-linearity
@@ -45,7 +45,7 @@ class Receiver(nn.Module):
         return torch.sigmoid(x)
 
 
-def loss(sender_input, _message, _receiver_input, receiver_output, _labels):
+def loss(sender_input, _message, _receiver_input, receiver_output, _labels, _aux_input):
     """
     The autoencoder's loss function; cross-entropy between the original and restored images.
     """

--- a/egg/zoo/mnist_vae/train.py
+++ b/egg/zoo/mnist_vae/train.py
@@ -74,6 +74,7 @@ class VAE_Game(nn.Module):
             sender_input=sender_input,
             receiver_input=None,
             labels=None,
+            aux_input=None,
             receiver_output=receiver_output.detach(),
             message=message.detach(),
             message_length=torch.ones(message.size(0)),

--- a/egg/zoo/mnist_vae/train.py
+++ b/egg/zoo/mnist_vae/train.py
@@ -94,7 +94,6 @@ class ImageDumpCallback(core.Callback):
         dump_dir = pathlib.Path.cwd() / "dump" / str(epoch)
         dump_dir.mkdir(exist_ok=True, parents=True)
 
-        state = self.trainer.game.train
         self.trainer.game.eval()
 
         for i in range(5):
@@ -109,7 +108,7 @@ class ImageDumpCallback(core.Callback):
             utils.save_image(
                 torch.cat([image, output], dim=1), dump_dir / (str(i) + ".png")
             )
-        self.trainer.game.train(state)
+        self.trainer.game.train()
 
 
 def main(params):

--- a/egg/zoo/objects_game/archs.py
+++ b/egg/zoo/objects_game/archs.py
@@ -12,7 +12,7 @@ class Sender(nn.Module):
         super(Sender, self).__init__()
         self.fc1 = nn.Linear(n_features, n_hidden)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input=None):
         return self.fc1(x).tanh()
 
 
@@ -21,7 +21,7 @@ class Receiver(nn.Module):
         super(Receiver, self).__init__()
         self.fc1 = nn.Linear(n_features, linear_units)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input=None):
         embedded_input = self.fc1(_input).tanh()
         energies = torch.matmul(embedded_input, torch.unsqueeze(x, dim=-1))
         return energies.squeeze()

--- a/egg/zoo/objects_game/train.py
+++ b/egg/zoo/objects_game/train.py
@@ -224,7 +224,9 @@ def check_args(args):
         )
 
 
-def loss(_sender_input, _message, _receiver_input, receiver_output, _labels):
+def loss(
+    _sender_input, _message, _receiver_input, receiver_output, _labels, _aux_input
+):
     acc = (receiver_output.argmax(dim=1) == _labels).detach().float()
     loss = F.cross_entropy(receiver_output, _labels, reduction="none")
     return loss, {"acc": acc}

--- a/egg/zoo/signal_game/archs.py
+++ b/egg/zoo/signal_game/archs.py
@@ -38,7 +38,7 @@ class InformedSender(nn.Module):
         )
         self.lin4 = nn.Linear(embedding_size, vocab_size, bias=False)
 
-    def forward(self, x, return_embeddings=False):
+    def forward(self, x, _aux_input=None):
         emb = self.return_embeddings(x)
 
         # in: h of size (batch_size, 1, game_size, embedding_size)
@@ -92,7 +92,7 @@ class Receiver(nn.Module):
         else:
             self.lin2 = nn.Linear(vocab_size, embedding_size, bias=False)
 
-    def forward(self, signal, x):
+    def forward(self, signal, x, _aux_input=None):
         # embed each image (left or right)
         emb = self.return_embeddings(x)
         # embed the signal

--- a/egg/zoo/signal_game/train.py
+++ b/egg/zoo/signal_game/train.py
@@ -52,7 +52,7 @@ def parse_arguments():
     return opt
 
 
-def loss(_sender_input, _message, _receiver_input, receiver_output, labels):
+def loss(_sender_input, _message, _receiver_input, receiver_output, labels, _aux_input):
     """
     Accuracy loss - non-differetiable hence cannot be used with GS
     """
@@ -60,7 +60,9 @@ def loss(_sender_input, _message, _receiver_input, receiver_output, labels):
     return -acc, {"acc": acc}
 
 
-def loss_nll(_sender_input, _message, _receiver_input, receiver_output, labels):
+def loss_nll(
+    _sender_input, _message, _receiver_input, receiver_output, labels, _aux_input
+):
     """
     NLL loss - differentiable and can be used with both GS and Reinforce
     """

--- a/egg/zoo/simclr/archs.py
+++ b/egg/zoo/simclr/archs.py
@@ -43,7 +43,7 @@ class VisionGameWrapper(nn.Module):
         self.game = game
         self.vision_module = vision_module
 
-    def forward(self, sender_input, labels, receiver_input=None):
+    def forward(self, sender_input, labels, receiver_input=None, _aux_input=None):
         x_i, x_j = sender_input
         sender_encoded_input, receiver_encoded_input = self.vision_module(x_i, x_j)
 

--- a/egg/zoo/simclr/losses.py
+++ b/egg/zoo/simclr/losses.py
@@ -22,7 +22,13 @@ class Loss:
         self.similarity = similarity
 
     def __call__(
-        self, _sender_input, message, _receiver_input, receiver_output, _labels
+        self,
+        _sender_input,
+        message,
+        _receiver_input,
+        receiver_output,
+        _labels,
+        _aux_input,
     ):
         input = torch.cat((message, receiver_output), dim=0)
 

--- a/egg/zoo/simple_autoenc/archs.py
+++ b/egg/zoo/simple_autoenc/archs.py
@@ -11,7 +11,7 @@ class Receiver(nn.Module):
         super(Receiver, self).__init__()
         self.output = nn.Linear(n_hidden, n_features)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input):
         return self.output(x)
 
 
@@ -20,6 +20,6 @@ class Sender(nn.Module):
         super(Sender, self).__init__()
         self.fc1 = nn.Linear(n_features, n_hidden)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input):
         x = self.fc1(x)
         return x

--- a/egg/zoo/simple_autoenc/train.py
+++ b/egg/zoo/simple_autoenc/train.py
@@ -112,7 +112,7 @@ def get_params(params):
     return args
 
 
-def loss(sender_input, _message, _receiver_input, receiver_output, _labels):
+def loss(sender_input, _message, _receiver_input, receiver_output, _labels, _aux_input):
     acc = (receiver_output.argmax(dim=1) == sender_input.argmax(dim=1)).detach().float()
     loss = F.cross_entropy(
         receiver_output, sender_input.argmax(dim=1), reduction="none"

--- a/egg/zoo/summation/archs.py
+++ b/egg/zoo/summation/archs.py
@@ -12,7 +12,7 @@ class Receiver(nn.Module):
         super(Receiver, self).__init__()
         self.output = nn.Linear(n_hidden, 2)
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input=None):
         return self.output(x)
 
 
@@ -48,7 +48,7 @@ class Encoder(nn.Module):
 
         self.embedding = nn.Embedding(vocab_size, embed_dim)
 
-    def forward(self, x):
+    def forward(self, x, _aux_input=None):
         messages, lengths = x
         emb = self.embedding(messages)
 

--- a/egg/zoo/summation/train.py
+++ b/egg/zoo/summation/train.py
@@ -77,7 +77,7 @@ def get_params():
     return args
 
 
-def loss(_sender_input, _message, _receiver_input, receiver_output, labels):
+def loss(_sender_input, _message, _receiver_input, receiver_output, labels, _aux_input):
     acc = (receiver_output.argmax(dim=1) == labels).detach().float()
     loss = F.cross_entropy(receiver_output, labels)
     return loss, {"acc": acc}
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     )
     trainer.train(n_epochs=opts.n_epochs)
 
-    sender_inputs, messages, _, receiver_outputs, labels = core.dump_sender_receiver(
+    sender_inputs, messages, _, receiver_outputs, labels = core.dump_interactions(
         game, test_loader, gs=True, device=device, variable_length=True
     )
 

--- a/egg/zoo/template/archs.py
+++ b/egg/zoo/template/archs.py
@@ -16,7 +16,9 @@ class Sender(nn.Module):
         super(Sender, self).__init__()
 
     def forward(
-        self, sender_input: torch.Tensor
+        self,
+        sender_input: torch.Tensor,
+        aux_input: Dict[str, torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Any]]:
         pass
 
@@ -26,7 +28,10 @@ class Receiver(nn.Module):
         super(Receiver, self).__init__()
 
     def forward(
-        self, message: torch.Tensor, receiver_input: torch.Tensor = None
+        self,
+        message: torch.Tensor,
+        receiver_input: torch.Tensor = None,
+        aux_input: Dict[str, torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Any]]:
         pass
 

--- a/egg/zoo/template/losses.py
+++ b/egg/zoo/template/losses.py
@@ -26,6 +26,7 @@ class Loss:
         receiver_input: torch.Tensor,
         receiver_output: torch.Tensor,
         labels: torch.Tensor,
+        aux_inpute: Dict[str, torch.Tensor],
     ) -> Tuple[torch.Tensor, Dict[str, Any]]:
         loss, acc = None, None
         return loss, {"acc": acc}

--- a/tests/test_toy_counting.py
+++ b/tests/test_toy_counting.py
@@ -33,7 +33,7 @@ class ToyAgent(torch.nn.Module):
         super(ToyAgent, self).__init__()
         self.fc1 = torch.nn.Linear(8, 1, bias=False)
 
-    def forward(self, x):
+    def forward(self, x, aux_input=None):
         x = self.fc1(x)
         return x
 
@@ -45,7 +45,7 @@ class ToyGame(torch.nn.Module):
         self.agent = agent
         self.criterion = torch.nn.MSELoss()
 
-    def forward(self, x, y):
+    def forward(self, x, y, z=None, aux_input=None):
         output = self.agent(x)
         output = output.squeeze(1)
         loss = self.criterion(output, y)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -26,7 +26,7 @@ class Receiver(torch.nn.Module):
     def __init__(self):
         super(Receiver, self).__init__()
 
-    def forward(self, x, _input):
+    def forward(self, x, _input, _aux_input):
         return x
 
 
@@ -35,7 +35,7 @@ class ToyAgent(torch.nn.Module):
         super(ToyAgent, self).__init__()
         self.fc1 = torch.nn.Linear(8, 2, bias=False)
 
-    def forward(self, x):
+    def forward(self, x, aux_input=None):
         x = self.fc1(x)
         return F.log_softmax(x, dim=1)
 
@@ -55,7 +55,7 @@ def test_temperature_updater_callback():
     core.init()
     sender = core.GumbelSoftmaxWrapper(ToyAgent(), temperature=1)
     receiver = Receiver()
-    loss = lambda sender_input, message, receiver_input, receiver_output, labels: (
+    loss = lambda sender_input, message, receiver_input, receiver_output, labels, aux_input: (
         F.cross_entropy(receiver_output, labels),
         {},
     )
@@ -81,7 +81,7 @@ def test_snapshoting():
     core.init()
     sender = core.GumbelSoftmaxWrapper(ToyAgent(), temperature=1)
     receiver = Receiver()
-    loss = lambda sender_input, message, receiver_input, receiver_output, labels: (
+    loss = lambda sender_input, message, receiver_input, receiver_output, labels, aux_input: (
         F.cross_entropy(receiver_output, labels),
         {},
     )
@@ -115,7 +115,7 @@ def test_max_snapshoting():
     core.init()
     sender = core.GumbelSoftmaxWrapper(ToyAgent(), temperature=1)
     receiver = Receiver()
-    loss = lambda sender_input, message, receiver_input, receiver_output, labels: (
+    loss = lambda sender_input, message, receiver_input, receiver_output, labels, aux_input: (
         F.cross_entropy(receiver_output, labels),
         {},
     )

--- a/tutorials/EGG walkthrough with a MNIST autoencoder.ipynb
+++ b/tutorials/EGG walkthrough with a MNIST autoencoder.ipynb
@@ -284,7 +284,7 @@
     "        self.fc = nn.Linear(500, output_size)\n",
     "        self.vision = vision\n",
     "        \n",
-    "    def forward(self, x):\n",
+    "    def forward(self, x, aux_input=None):\n",
     "        with torch.no_grad():\n",
     "            x = self.vision(x)\n",
     "        x = self.fc(x)\n",
@@ -296,7 +296,7 @@
     "        super(Receiver, self).__init__()\n",
     "        self.fc = nn.Linear(input_size, 784)\n",
     "\n",
-    "    def forward(self, channel_input, receiver_input=None):\n",
+    "    def forward(self, channel_input, receiver_input=None, aux_input=None):\n",
     "        x = self.fc(channel_input)\n",
     "        return torch.sigmoid(x)\n",
     "\n",
@@ -333,7 +333,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def loss(sender_input, _message, _receiver_input, receiver_output, _labels):\n",
+    "def loss(sender_input, _message, _receiver_input, receiver_output, _labels, _aux_input=None):\n",
     "    loss = F.binary_cross_entropy(receiver_output, sender_input.view(-1, 784), reduction='none').mean(dim=1)\n",
     "    return loss, {}"
    ]
@@ -1839,7 +1839,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
Add support for custom batches.

## Related Issue (if any)
#159 

## Motivation and Context
Some games might require additional (possibly non-tensor) data to be passed to the agents. This PR supports this by using a custom Batch class that incapsulates the existing elements of a batch + a dictionary of arbitrary data.

Backwards compatibility is provided with a function that generates a Batch element from a tuple of tensors, as this is the current format for batched data in EGG.

Please note that in this implementation a label parameter is now made optional as it is not always needed e.g. in reconstruction games.

## How Has This Been Tested?
doctest pass. UTs are failing as a change in EGG games and agents (+ existing implementations in egg/zoo) should be added


TODO:

- [x] handle concatenating the aux field of a batch when batch interactions are aggregated at the end of each epoch
- [x] change signature of games and agents forward pass