### PR TITLE
rename master refs to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ possible.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ with PyTorch. However, to get a taste of communication games without writing any
 
 <details><summary>List of example and tutorial games</summary><p>
  
- * [`MNIST autoencoder tutorial`](/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb): A Jupyter tutorial that implements a MNIST discrete auto-encoder step-by-step, covering the basic concepts of EGG. The tutorial starts with pre-training a "vision" module and builds single- and multiple symbol auto-encoder communication games with channel optimization done by Reinforce and Gumbel-Softmax relaxation ([notebook](/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb) / [colab](https://colab.research.google.com/github/facebookresearch/EGG/blob/master/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb)).
+ * [`MNIST autoencoder tutorial`](/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb): A Jupyter tutorial that implements a MNIST discrete auto-encoder step-by-step, covering the basic concepts of EGG. The tutorial starts with pre-training a "vision" module and builds single- and multiple symbol auto-encoder communication games with channel optimization done by Reinforce and Gumbel-Softmax relaxation ([notebook](/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb) / [colab](https://colab.research.google.com/github/facebookresearch/EGG/blob/main/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb)).
  
 * [`egg/zoo/basic_games`](/egg/zoo/basic_games): Simple implementations of reconstruction and discrimination games, taking their inputs from text files, and with thoroughly annotated code. These might be a good starting point to learn to play with EGG.
  
@@ -48,7 +48,7 @@ with PyTorch. However, to get a taste of communication games without writing any
   
   * [`egg/zoo/compo_vs_generalization`](egg/zoo/compo_vs_generalization) _Compositionality and Generalization in Emergent Languages._ Rahma Chaabouni, Eugene Kharitonov, Diane Bouchacourt, Emmanuel Dupoux, Marco Baroni. ACL 2020.
   
-  * [`egg/zoo/language_bottleneck`](/egg/zoo/language_bottleneck) _Entropy Minimization In Emergent Languages._ Eugene Kharitonov, Rahma Chaabouni, Diane Bouchacourt, Marco Baroni. ICML 2020. `egg/zoo/language_bottleneck` contains a set of games that study the information bottleneck property of the discrete communication channel. This poperty is illustrated in an EGG-based example of MNIST-based style transfer without an adversary ([notebook](/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb) / [colab](https://colab.research.google.com/github/facebookresearch/EGG/blob/master/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb)).
+  * [`egg/zoo/language_bottleneck`](/egg/zoo/language_bottleneck) _Entropy Minimization In Emergent Languages._ Eugene Kharitonov, Rahma Chaabouni, Diane Bouchacourt, Marco Baroni. ICML 2020. `egg/zoo/language_bottleneck` contains a set of games that study the information bottleneck property of the discrete communication channel. This poperty is illustrated in an EGG-based example of MNIST-based style transfer without an adversary ([notebook](/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb) / [colab](https://colab.research.google.com/github/facebookresearch/EGG/blob/main/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb)).
 
 </p></details>
 
@@ -102,7 +102,7 @@ The repo is organised as follows:
 
 ## How-to-Start and Learning more
 * Our EMNLP'19 Demo [paper](https://aclanthology.org/D19-3010/) provides a high-level view of the toolkit and points to further resources.
-* The step-by-step [`MNIST autoencoder tutorial`](/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb) goes over all essential steps to create a full-featured communication game with variable length messages between the agents. NB: depending on your computational resources, this might take a while to run! [(open in colab)](https://colab.research.google.com/github/facebookresearch/EGG/blob/master/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb)
+* The step-by-step [`MNIST autoencoder tutorial`](/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb) goes over all essential steps to create a full-featured communication game with variable length messages between the agents. NB: depending on your computational resources, this might take a while to run! [(open in colab)](https://colab.research.google.com/github/facebookresearch/EGG/blob/main/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb)
 * The simplest starter code is in [`egg/zoo/basic_games`](/egg/zoo/basic_games), providing implementations of basic reconstruction and discrimination games. Input can be provided through text files, and the code is thoroughly commented.
 * Another good starting point to implement a Sender/Receiver game is the MNIST autoencoder
 game, [MNIST auto-encoder game](/egg/zoo/mnist_autoenc). The game features both Gumbel-Softmax 

--- a/docs/CL.md
+++ b/docs/CL.md
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     
 ```
     
-The list of the supported "common" parameters can be found in [util.py](https://github.com/facebookresearch/EGG/blob/master/egg/core/util.py) and it includes both parameters that are read 
+The list of the supported "common" parameters can be found in [util.py](https://github.com/facebookresearch/EGG/blob/main/egg/core/util.py) and it includes both parameters that are read 
 by EGG itself and those that could be used by the user. Below we briefly discuss some important parameters in these two classes.
 
 ### EGG-used parameters

--- a/egg/zoo/basic_games/play.py
+++ b/egg/zoo/basic_games/play.py
@@ -17,7 +17,7 @@ from egg.zoo.basic_games.data_readers import AttValDiscriDataset, AttValRecoData
 
 
 # the following section specifies parameters that are specific to our games: we will also inherit the
-# standard EGG parameters from https://github.com/facebookresearch/EGG/blob/master/egg/core/util.py
+# standard EGG parameters from https://github.com/facebookresearch/EGG/blob/main/egg/core/util.py
 def get_params(params):
     parser = argparse.ArgumentParser()
     # arguments controlling the game type

--- a/egg/zoo/language_bottleneck/README.md
+++ b/egg/zoo/language_bottleneck/README.md
@@ -2,7 +2,7 @@ Here you can find a set of the games/tasks that are used the following paper:
  * _Entropy Minimization In Emergent Languages_. Eugene Kharitonov, Rahma Chaabouni, Diane Bouchacourt, Marco Baroni. ICML 2020.
  [arxiv](https://arxiv.org/abs/1905.13687).
 
-To get a glimpse of some of the interesting things that can be done with Information Bottlenecks, see this tiny MNIST style transfer notebook: [notebook](/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb) / [colab](https://colab.research.google.com/github/facebookresearch/EGG/blob/master/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb).
+To get a glimpse of some of the interesting things that can be done with Information Bottlenecks, see this tiny MNIST style transfer notebook: [notebook](/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb) / [colab](https://colab.research.google.com/github/facebookresearch/EGG/blob/main/egg/zoo/language_bottleneck/mnist-style-transfer-via-bottleneck.ipynb).
 
 # Structure
 

--- a/egg/zoo/mnist_autoenc/README.md
+++ b/egg/zoo/mnist_autoenc/README.md
@@ -7,4 +7,4 @@ The training can be started as:
 python -m egg.zoo.mnist_autoenc.train --vocab_size=10 --n_epochs=50 --batch_size=16 --random_seed=7
 ```
 
-Please refer to the [MNIST autoencoder tutorial](https://github.com/facebookresearch/EGG/blob/master/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb) for more details.
+Please refer to the [MNIST autoencoder tutorial](https://github.com/facebookresearch/EGG/blob/main/tutorials/EGG%20walkthrough%20with%20a%20MNIST%20autoencoder.ipynb) for more details.

--- a/egg/zoo/signal_game/README.md
+++ b/egg/zoo/signal_game/README.md
@@ -34,7 +34,7 @@ The game can be configured with the following command-line parameters:
  * `--n_epochs` the number of training epochs to run (default: 10)
  * `--random_seed` sets the random seed
  * `--lr` , `--optimizer`, ...
- see [this doc](https://github.com/facebookresearch/EGG/blob/master/docs/CL.md).
+ see [this doc](https://github.com/facebookresearch/EGG/blob/main/docs/CL.md).
 
  
  


### PR DESCRIPTION
Renaming all references to `master` to `main` following the recent brach renaming
