### PR TITLE
fix broken contributing link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you find EGG useful in your research, please cite this repository:
 ```
 
 ## Contributing
-Please read the contribution [guide](CONTRIBUTING.md).
+Please read the contribution [guide](.github/CONTRIBUTING.md).
 
 
 ## Testing


### PR DESCRIPTION
## Description
Link to CONTRIBUTING file on README gave me 404 and I found what seems to be the correct file under the `.github` subdir