### PR TITLE
updating of info table removed when use_info_table=false

### DIFF
--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -426,7 +426,7 @@ class ProgressBarLogger(Callback):
         self.n_epochs = n_epochs
         self.train_data_len = train_data_len
         self.test_data_len = test_data_len
-        self.use_info_table= use_info_table
+        self.use_info_table = use_info_table
         self.progress = CustomProgress(
             TextColumn(
                 "[bold]Epoch {task.fields[cur_epoch]}/{task.fields[n_epochs]} | [blue]{task.fields[mode]}",

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -426,6 +426,7 @@ class ProgressBarLogger(Callback):
         self.n_epochs = n_epochs
         self.train_data_len = train_data_len
         self.test_data_len = test_data_len
+        self.use_info_table= use_info_table
         self.progress = CustomProgress(
             TextColumn(
                 "[bold]Epoch {task.fields[cur_epoch]}/{task.fields[n_epochs]} | [blue]{task.fields[mode]}",
@@ -503,8 +504,9 @@ class ProgressBarLogger(Callback):
             mode="Train",
         )
 
-        od = self.build_od(logs, loss, epoch)
-        self.progress.update_info_table(od, "train")
+        if self.use_info_table:
+            od = self.build_od(logs, loss, epoch)
+            self.progress.update_info_table(od, "train")
 
     def on_validation_begin(self, epoch: int):
         self.progress.reset(
@@ -538,8 +540,9 @@ class ProgressBarLogger(Callback):
             mode="Test",
         )
 
-        od = self.build_od(logs, loss, epoch)
-        self.progress.update_info_table(od, "test")
+        if self.use_info_table:
+            od = self.build_od(logs, loss, epoch)
+            self.progress.update_info_table(od, "test")
 
     def on_train_end(self):
         self.progress.stop()


### PR DESCRIPTION
The  `use_info_table` bool parameter was not taken into consideration when updating the infotable at the end of the train/val epoch. This resulted in an error when trying to update such table without having instantiated it in the first place.