### PR TITLE
 Add batch_id in game call and logging strategy 

### DIFF
--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -426,7 +426,7 @@ class ProgressBarLogger(Callback):
         self.n_epochs = n_epochs
         self.train_data_len = train_data_len
         self.test_data_len = test_data_len
-        self.use_info_table= use_info_table
+        self.use_info_table = use_info_table
         self.progress = CustomProgress(
             TextColumn(
                 "[bold]Epoch {task.fields[cur_epoch]}/{task.fields[n_epochs]} | [blue]{task.fields[mode]}",

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -426,6 +426,7 @@ class ProgressBarLogger(Callback):
         self.n_epochs = n_epochs
         self.train_data_len = train_data_len
         self.test_data_len = test_data_len
+        self.use_info_table= use_info_table
         self.progress = CustomProgress(
             TextColumn(
                 "[bold]Epoch {task.fields[cur_epoch]}/{task.fields[n_epochs]} | [blue]{task.fields[mode]}",
@@ -503,8 +504,9 @@ class ProgressBarLogger(Callback):
             mode="Train",
         )
 
-        od = self.build_od(logs, loss, epoch)
-        self.progress.update_info_table(od, "train")
+        if self.use_info_table:
+            od = self.build_od(logs, loss, epoch)
+            self.progress.update_info_table(od, "train")
 
     def on_validation_begin(self, epoch: int):
         self.progress.reset(
@@ -538,8 +540,9 @@ class ProgressBarLogger(Callback):
             mode="Test",
         )
 
-        od = self.build_od(logs, loss, epoch)
-        self.progress.update_info_table(od, "test")
+        if self.use_info_table:
+            od = self.build_od(logs, loss, epoch)
+            self.progress.update_info_table(od, "test")
 
     def on_train_end(self):
         self.progress.stop()

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -24,7 +24,7 @@ class LoggingStrategy:
 
     def filtered_interaction(
         self,
-            batch_id: int,
+        batch_id: int,
         sender_input: Optional[torch.Tensor],
         receiver_input: Optional[torch.Tensor],
         labels: Optional[torch.Tensor],
@@ -34,7 +34,6 @@ class LoggingStrategy:
         message_length: Optional[torch.Tensor],
         aux: Dict[str, torch.Tensor],
     ):
-
         return Interaction(
             sender_input=sender_input if self.store_sender_input else None,
             receiver_input=receiver_input if self.store_receiver_input else None,
@@ -142,9 +141,12 @@ class Interaction:
 
         assert interactions, "interaction list must not be empty"
         has_aux_input = interactions[0].aux_input is not None
+
         # filter out empty interactions
-        interactions=[x for x in interactions if not x.is_empty()]
+        interactions = [x for x in interactions if not x.is_empty()]
+
         for x in interactions:
+
             assert len(x.aux) == len(interactions[0].aux)
             if has_aux_input:
                 assert len(x.aux_input) == len(

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -24,6 +24,7 @@ class LoggingStrategy:
 
     def filtered_interaction(
         self,
+            batch_id: int,
         sender_input: Optional[torch.Tensor],
         receiver_input: Optional[torch.Tensor],
         labels: Optional[torch.Tensor],
@@ -141,6 +142,8 @@ class Interaction:
 
         assert interactions, "interaction list must not be empty"
         has_aux_input = interactions[0].aux_input is not None
+        # filter out empty interactions
+        interactions=[x for x in interactions if not x.is_empty()]
         for x in interactions:
             assert len(x.aux) == len(interactions[0].aux)
             if has_aux_input:
@@ -175,6 +178,9 @@ class Interaction:
     @staticmethod
     def empty() -> "Interaction":
         return Interaction(None, None, None, {}, None, None, None, {})
+
+    def is_empty(self) -> bool:
+        return self == self.empty()
 
     @staticmethod
     def gather_distributed_interactions(log: "Interaction") -> Optional["Interaction"]:

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -165,7 +165,6 @@ class Trainer:
     def eval(self):
         mean_loss = 0.0
         interactions = []
-        n_batches = 0
         self.game.eval()
         with torch.no_grad():
             for batch_id, batch in enumerate(self.validation_data):
@@ -189,7 +188,6 @@ class Trainer:
                     )
 
                 interactions.append(interaction)
-                n_batches += 1
 
         mean_loss /= batch_id
         full_interaction = Interaction.from_iterable(interactions)


### PR DESCRIPTION
Problem: The logging strategy class takes no consideration of the current batch id. 

Desired outcome: It can be desirable to log information based on the batch_id (typically with the formula `batch_id%logging_step`) when dealing with large data types such as images.

Proposed Solution: in this PR, this issue is addressed by passing to the `self.game()` call in the `train_epoch` and `eval` methods an additional int which is the `batch_id`.  Moreover a filtering pass had been added inside the `from_iterable` method of the `Interaction` class. This filtering is based on a new method `is_empty` that checks if the current interaction is empty.

Downsides: the introduction of this new  `batch_id` parameter probably breaks the compatibility with most `game()` calls. On the other side, compatibility can be enforced again by simply adding an empty argument inside each game forward method.