### PR TITLE
Enanched logging strategy 

### DIFF
--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -426,6 +426,7 @@ class ProgressBarLogger(Callback):
         self.n_epochs = n_epochs
         self.train_data_len = train_data_len
         self.test_data_len = test_data_len
+        self.use_info_table = use_info_table
         self.progress = CustomProgress(
             TextColumn(
                 "[bold]Epoch {task.fields[cur_epoch]}/{task.fields[n_epochs]} | [blue]{task.fields[mode]}",
@@ -482,6 +483,7 @@ class ProgressBarLogger(Callback):
             n_epochs=self.n_epochs,
             mode="Train",
         )
+
         self.progress.start_task(self.train_p)
         self.progress.update(self.train_p, visible=True)
 
@@ -503,8 +505,9 @@ class ProgressBarLogger(Callback):
             mode="Train",
         )
 
-        od = self.build_od(logs, loss, epoch)
-        self.progress.update_info_table(od, "train")
+        if self.use_info_table:
+            od = self.build_od(logs, loss, epoch)
+            self.progress.update_info_table(od, "train")
 
     def on_validation_begin(self, epoch: int):
         self.progress.reset(
@@ -538,8 +541,9 @@ class ProgressBarLogger(Callback):
             mode="Test",
         )
 
-        od = self.build_od(logs, loss, epoch)
-        self.progress.update_info_table(od, "test")
+        if self.use_info_table:
+            od = self.build_od(logs, loss, epoch)
+            self.progress.update_info_table(od, "test")
 
     def on_train_end(self):
         self.progress.stop()

--- a/egg/core/callbacks.py
+++ b/egg/core/callbacks.py
@@ -426,7 +426,6 @@ class ProgressBarLogger(Callback):
         self.n_epochs = n_epochs
         self.train_data_len = train_data_len
         self.test_data_len = test_data_len
-        self.use_info_table = use_info_table
         self.progress = CustomProgress(
             TextColumn(
                 "[bold]Epoch {task.fields[cur_epoch]}/{task.fields[n_epochs]} | [blue]{task.fields[mode]}",
@@ -483,7 +482,6 @@ class ProgressBarLogger(Callback):
             n_epochs=self.n_epochs,
             mode="Train",
         )
-
         self.progress.start_task(self.train_p)
         self.progress.update(self.train_p, visible=True)
 
@@ -505,9 +503,8 @@ class ProgressBarLogger(Callback):
             mode="Train",
         )
 
-        if self.use_info_table:
-            od = self.build_od(logs, loss, epoch)
-            self.progress.update_info_table(od, "train")
+        od = self.build_od(logs, loss, epoch)
+        self.progress.update_info_table(od, "train")
 
     def on_validation_begin(self, epoch: int):
         self.progress.reset(
@@ -541,9 +538,8 @@ class ProgressBarLogger(Callback):
             mode="Test",
         )
 
-        if self.use_info_table:
-            od = self.build_od(logs, loss, epoch)
-            self.progress.update_info_table(od, "test")
+        od = self.build_od(logs, loss, epoch)
+        self.progress.update_info_table(od, "test")
 
     def on_train_end(self):
         self.progress.stop()

--- a/egg/core/gs_wrappers.py
+++ b/egg/core/gs_wrappers.py
@@ -2,14 +2,14 @@
 
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Callable, Optional
+from typing import Callable
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions import RelaxedOneHotCategorical
 
-from .interaction import Interaction, LoggingStrategy
+from .interaction import Interaction
 
 
 def gumbel_softmax_sample(

--- a/egg/core/gs_wrappers.py
+++ b/egg/core/gs_wrappers.py
@@ -156,7 +156,7 @@ class SymbolGameGS(nn.Module):
           * receiver_input: input to Receiver from dataset
           * receiver_output: output of Receiver
           * labels: labels that come from dataset
-        :param kwargs: used for deprecated logging strategy
+        :param kwargs: kwargs arguments
 
         """
         super(SymbolGameGS, self).__init__()
@@ -454,7 +454,7 @@ class SenderReceiverRnnGS(nn.Module):
           of the same shape. The loss will be minimized during training, and the auxiliary information aggregated over
           all batches in the dataset.
         :param length_cost: the penalty applied to Sender for each symbol produced
-        :param kwargs: used for deprecated logging strategy
+        :param kwargs:  kwargs arguments
 
         """
         super(SenderReceiverRnnGS, self).__init__()

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -110,6 +110,10 @@ class Interaction:
         # filter out empty interactions
         interactions = [x for x in interactions if not x.is_empty()]
 
+        if len(interactions) == 0:
+            # we still need at least one empty interaction in the list, so it is empty after the filtering add one
+            interactions = [Interaction.empty()]
+
         for x in interactions:
             assert len(x.aux) == len(interactions[0].aux)
             if has_aux_input:
@@ -203,11 +207,13 @@ def deprecated(func):
     when the function is used."""
 
     def warn():
-        warnings.simplefilter('always', DeprecationWarning)  # turn off filter
-        warnings.warn("Call to deprecated function {}.".format(func.__name__),
-                      category=DeprecationWarning,
-                      stacklevel=2)
-        warnings.simplefilter('default', DeprecationWarning)  # reset filter
+        warnings.simplefilter("always", DeprecationWarning)  # turn off filter
+        warnings.warn(
+            f"Call to deprecated version of '{func.__name__}'. You should pass an Interaction class based on the input dict ",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        warnings.simplefilter("default", DeprecationWarning)  # reset filter
 
     @functools.wraps(func)
     def new_func(*args, **kwargs):

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -5,7 +5,6 @@
 import functools
 import warnings
 from dataclasses import dataclass
-from itertools import groupby
 from typing import Dict, Iterable, Optional, Union
 
 import torch
@@ -93,9 +92,9 @@ class Interaction:
         RuntimeError: Appending empty and non-empty interactions logs. Normally this shouldn't happen!
         """
 
-        def _all_equal(iterable):
-            g = groupby(iterable)
-            return next(g, True) and not next(g, False)
+        def _all_equal(len_list):
+            g = set(len_list)
+            return len(g) == 1
 
         def _check_cat(lst):
             if all(x is None for x in lst):
@@ -106,11 +105,12 @@ class Interaction:
                     "Appending empty and non-empty interactions logs. "
                     "Normally this shouldn't happen!"
                 )
-
+            # is all elem are tensor stack
             if all([isinstance(x, torch.Tensor) for x in lst]):
                 return torch.stack(lst, dim=0)
+            # if all elem are list
             elif all([isinstance(x, list) for x in lst]):
-                # lst is a list of lists
+                # check that all elems have same length
                 if _all_equal([len(x) for x in lst]):
                     return lst
                 else:

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -5,7 +5,7 @@
 import functools
 import warnings
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional, Union, List
+from typing import Dict, Iterable, List, Optional, Union
 
 import torch
 import torch.distributed as distrib

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -287,7 +287,7 @@ class LoggingStrategy:
 
     @classmethod
     def minimal(cls):
-        args = [False] * 6 + [True]
+        args = [False] * 7
         return cls(*args)
 
     @classmethod

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -218,7 +218,7 @@ def deprecated(func):
     @functools.wraps(func)
     def new_func(*args, **kwargs):
 
-        if not "batch_id" in kwargs.keys():
+        if "batch_id" not in kwargs.keys():
             warn()
             interaction = Interaction(**kwargs)
             return func(*args, interaction=interaction, batch_id=-1)

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -5,7 +5,7 @@
 import functools
 import warnings
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional, Union
+from typing import Dict, Iterable, Optional, Union, List
 
 import torch
 import torch.distributed as distrib
@@ -16,18 +16,18 @@ from egg.core.batch import Batch
 @dataclass(repr=True, unsafe_hash=True)
 class Interaction:
     # incoming data
-    sender_input: Optional[Union[torch.Tensor, list]]
-    receiver_input: Optional[Union[torch.Tensor, list]]
-    labels: Optional[Union[torch.Tensor, list]]
-    aux_input: Optional[Dict[str, Union[torch.Tensor, list]]]
+    sender_input: Optional[Union[torch.Tensor, List]]
+    receiver_input: Optional[Union[torch.Tensor, List]]
+    labels: Optional[Union[torch.Tensor, List]]
+    aux_input: Optional[Dict[str, Union[torch.Tensor, List]]]
 
     # what agents produce
-    message: Optional[Union[torch.Tensor, list]]
-    receiver_output: Optional[Union[torch.Tensor, list]]
+    message: Optional[Union[torch.Tensor, List]]
+    receiver_output: Optional[Union[torch.Tensor, List]]
 
     # auxilary info
-    message_length: Optional[Union[torch.Tensor, list]]
-    aux: Dict[str, Union[torch.Tensor, list]]
+    message_length: Optional[Union[torch.Tensor, List]]
+    aux: Dict[str, Union[torch.Tensor, List]]
 
     @property
     def size(self):

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -201,10 +201,9 @@ class Interaction:
         return synced_interacton
 
 
-def deprecated(func):
-    """This is a decorator which can be used to mark functions
-    as deprecated. It will result in a warning being emitted
-    when the function is used."""
+def old_signature_warning(func):
+    """This is a decorator which is used to warn users on the new signature for the 'filtered_interaction'.
+    ."""
 
     def warn():
         warnings.simplefilter("always", DeprecationWarning)  # turn off filter
@@ -222,8 +221,7 @@ def deprecated(func):
             warn()
             interaction = Interaction(**kwargs)
             return func(*args, interaction=interaction, batch_id=-1)
-        else:
-            return func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     return new_func
 
@@ -237,14 +235,13 @@ class LoggingStrategy:
     store_message: bool = True
     store_receiver_output: bool = True
     store_message_length: bool = True
-    logging_step: int = -1
+    logging_step: int = 0
 
-    @deprecated
+    @old_signature_warning
     def filtered_interaction(self, interaction: Interaction, batch_id: int):
 
-        filtered_interaction = None
-        # when logging_step=-1 do not consider batch_id so log. Or then is time then log
-        if self.logging_step <= 0 or batch_id % self.logging_step == 0:
+        # when logging_step==0 log. Else consider batch_id value
+        if self.logging_step == 0 or batch_id % self.logging_step == 0:
 
             filtered_interaction = Interaction(
                 sender_input=interaction.sender_input
@@ -265,7 +262,7 @@ class LoggingStrategy:
                 aux=interaction.aux,
             )
         else:
-            filtered_interaction = Interaction().empty()
+            filtered_interaction = Interaction.empty()
 
         return filtered_interaction
 

--- a/egg/core/interaction.py
+++ b/egg/core/interaction.py
@@ -5,7 +5,7 @@
 import functools
 import warnings
 from dataclasses import dataclass
-from itertools import chain, groupby
+from itertools import groupby
 from typing import Dict, Iterable, Optional, Union
 
 import torch

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -171,6 +171,7 @@ class Trainer:
 
     def eval(self, data=None):
         mean_loss = 0.0
+        batch_id = 1
         interactions = []
         validation_data = self.validation_data if data is None else data
         self.game.eval()
@@ -204,7 +205,7 @@ class Trainer:
         mean_loss /= batch_id
         full_interaction = Interaction.from_iterable(interactions)
 
-        return mean_loss.item(), full_interaction
+        return float(mean_loss), full_interaction
 
     def train_epoch(self):
         mean_loss = 0
@@ -272,7 +273,7 @@ class Trainer:
 
         mean_loss /= n_batches
         full_interaction = Interaction.from_iterable(interactions)
-        return mean_loss.item(), full_interaction
+        return float(mean_loss), full_interaction
 
     def train(self, n_epochs):
         for callback in self.callbacks:

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -207,7 +207,7 @@ class Trainer:
 
         if not warn_on_empty_dataset(n_batches, is_train=False):
             mean_loss /= n_batches
-            mean_loss= mean_loss.item()
+            mean_loss = mean_loss.item()
 
         full_interaction = Interaction.from_iterable(interactions)
 

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -207,7 +207,7 @@ class Trainer:
 
         if not warn_on_empty_dataset(n_batches, is_train=False):
             mean_loss /= n_batches
-            mean_loss.item()
+            mean_loss= mean_loss.item()
 
         full_interaction = Interaction.from_iterable(interactions)
 

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -209,7 +209,7 @@ class Trainer:
 
     def train_epoch(self):
         mean_loss = 0
-        n_batches = 0
+        batch_id = 1
         interactions = []
 
         self.game.train()
@@ -254,7 +254,6 @@ class Trainer:
 
                 self.optimizer.zero_grad()
 
-            n_batches += 1
             mean_loss += optimized_loss.detach()
             if (
                 self.distributed_context.is_distributed
@@ -271,7 +270,7 @@ class Trainer:
         if self.optimizer_scheduler:
             self.optimizer_scheduler.step()
 
-        mean_loss /= n_batches
+        mean_loss /= batch_id
         full_interaction = Interaction.from_iterable(interactions)
         return float(mean_loss), full_interaction
 

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -62,7 +62,7 @@ class Trainer:
         :param optimizer: An instance of torch.optim.Optimizer
         :param optimizer_scheduler: An optimizer scheduler to adjust lr throughout training
         :param train_data: A DataLoader for the training set
-        :param validation_data: A DataLoader for the validation set  (can be None)
+        :param validation_data: A DataLoader for the validation set (can be None)
         :param device: A torch.device on which to tensors should be stored
         :param callbacks: A list of egg.core.Callback objects that can encapsulate monitoring or checkpointing
         :param train_logging_strategy, val_logging_strategy: specify what parts of interactions to persist for

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -182,7 +182,7 @@ class Trainer:
                 batch = batch.to(self.device)
                 optimized_loss, interaction = self.game(*batch)
                 interaction = self.val_logging_strategy.filtered_interaction(
-                    interaction, n_batches
+                    interaction=interaction, batch_id=n_batches
                 )
 
                 if (
@@ -226,7 +226,7 @@ class Trainer:
             with context:
                 optimized_loss, interaction = self.game(*batch)
                 interaction = self.train_logging_strategy.filtered_interaction(
-                    interaction, batch_id
+                    interaction=interaction, batch_id=batch_id
                 )
 
                 if self.update_freq > 1:

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -171,9 +171,9 @@ class Trainer:
             self.scaler = None
 
     def eval(self, data=None):
-        mean_loss = 0
-        n_batches = 0
+        mean_loss = 0.0
         interactions = []
+        n_batches = 0
         validation_data = self.validation_data if data is None else data
         self.game.eval()
         with torch.no_grad():

--- a/egg/core/trainers.py
+++ b/egg/core/trainers.py
@@ -62,7 +62,7 @@ class Trainer:
         :param optimizer: An instance of torch.optim.Optimizer
         :param optimizer_scheduler: An optimizer scheduler to adjust lr throughout training
         :param train_data: A DataLoader for the training set
-        :param validation_data: A DataLoader for the validation set (can be None)
+        :param validation_data: A DataLoader for the validation set  (can be None)
         :param device: A torch.device on which to tensors should be stored
         :param callbacks: A list of egg.core.Callback objects that can encapsulate monitoring or checkpointing
         :param train_logging_strategy, val_logging_strategy: specify what parts of interactions to persist for

--- a/egg/zoo/compositional_efficiency/continuous.py
+++ b/egg/zoo/compositional_efficiency/continuous.py
@@ -59,10 +59,14 @@ def main(params):
     device = opts.device
 
     train_data = SphereData(n_points=int(opts.n_points))
-    train_loader = DataLoader(train_data, batch_size=opts.batch_size, shuffle=True)
+    train_loader = DataLoader(
+        train_data, batch_size=opts.batch_size, shuffle=True, drop_last=True
+    )
 
     test_data = SphereData(n_points=int(1e3))
-    test_loader = DataLoader(train_data, batch_size=opts.batch_size, shuffle=False)
+    test_loader = DataLoader(
+        train_data, batch_size=opts.batch_size, shuffle=False, drop_last=True
+    )
 
     sender = CircleSender(opts.vocab_size)
 

--- a/egg/zoo/compositional_efficiency/discrete.py
+++ b/egg/zoo/compositional_efficiency/discrete.py
@@ -130,10 +130,14 @@ def main(params):
     opts.vocab_size = n_v
 
     train_data = AttributeValueData(n_attributes=n_a, n_values=n_v, mul=1, mode="train")
-    train_loader = DataLoader(train_data, batch_size=opts.batch_size, shuffle=True)
+    train_loader = DataLoader(
+        train_data, batch_size=opts.batch_size, shuffle=True, drop_last=True
+    )
 
     test_data = AttributeValueData(n_attributes=n_a, n_values=n_v, mul=1, mode="test")
-    test_loader = DataLoader(test_data, batch_size=opts.batch_size, shuffle=False)
+    test_loader = DataLoader(
+        test_data, batch_size=opts.batch_size, shuffle=False, drop_last=True
+    )
 
     print(f"# Size of train {len(train_data)} test {len(test_data)}")
 

--- a/egg/zoo/mnist_vae/train.py
+++ b/egg/zoo/mnist_vae/train.py
@@ -120,12 +120,14 @@ def main(params):
         datasets.MNIST("./data", train=True, download=True, transform=transform),
         batch_size=opts.batch_size,
         shuffle=True,
+        drop_last=True,
         **kwargs
     )
     test_loader = torch.utils.data.DataLoader(
         datasets.MNIST("./data", train=False, transform=transform),
         batch_size=opts.batch_size,
         shuffle=True,
+        drop_last=True,
         **kwargs
     )
 

--- a/tests/test_games_do_not_fail.py
+++ b/tests/test_games_do_not_fail.py
@@ -92,7 +92,7 @@ def test_compo_generalization():
 def test_compositional_efficiency():
     run_game(
         "egg.zoo.compositional_efficiency.discrete",
-        dict(n_a=2, n_v=11, n_epochs=1, language="identity"),
+        dict(n_a=2, n_v=11, n_epochs=1, language="identity", batch_size=16),
     )
     run_game(
         "egg.zoo.compositional_efficiency.continuous", dict(vocab_size=5, n_epochs=1)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -22,6 +22,11 @@ class Dataset:
         return iter([(BATCH_X, BATCH_Y)])
 
 
+class EmptyDataset:
+    def __iter__(self):
+        return iter([])
+
+
 class Receiver(torch.nn.Module):
     def __init__(self):
         super(Receiver, self).__init__()
@@ -170,3 +175,15 @@ def test_early_stopping():
     )
     trainer.train(1)
     assert trainer.should_stop
+
+
+def test_empty_dataset():
+    core.init(params=[])
+    game, data = MockGame(), EmptyDataset()
+    trainer = core.Trainer(
+        game=game,
+        optimizer=torch.optim.Adam(game.parameters()),
+        train_data=data,
+        validation_data=data,
+    )
+    trainer.train(1)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -6,7 +6,6 @@ import shutil
 import sys
 from pathlib import Path
 
-import pytest
 import torch
 from torch.nn import functional as F
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -57,7 +57,7 @@ class MockGame(torch.nn.Module):
 
 
 def test_temperature_updater_callback():
-    core.init()
+    core.init(params=[])
     sender = core.GumbelSoftmaxWrapper(ToyAgent(), temperature=1)
     receiver = Receiver()
     loss = lambda sender_input, message, receiver_input, receiver_output, labels, aux_input: (
@@ -83,7 +83,7 @@ def test_temperature_updater_callback():
 def test_snapshoting():
     CHECKPOINT_PATH = Path("./test_checkpoints")
 
-    core.init()
+    core.init(params=[])
     sender = core.GumbelSoftmaxWrapper(ToyAgent(), temperature=1)
     receiver = Receiver()
     loss = lambda sender_input, message, receiver_input, receiver_output, labels, aux_input: (
@@ -123,7 +123,7 @@ def test_snapshoting():
 def test_max_snapshoting():
     CHECKPOINT_PATH = Path("./test_checkpoints")
 
-    core.init()
+    core.init(params=[])
     sender = core.GumbelSoftmaxWrapper(ToyAgent(), temperature=1)
     receiver = Receiver()
     loss = lambda sender_input, message, receiver_input, receiver_output, labels, aux_input: (
@@ -186,4 +186,11 @@ def test_empty_dataset():
         train_data=data,
         validation_data=data,
     )
-    trainer.train(1)
+
+    passed = False
+    try:
+        trainer.train(1)
+    except AssertionError:
+        passed = True
+
+    assert passed, "The empty dataset assertion has not been raised"

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -190,7 +190,7 @@ def test_empty_dataset():
     passed = False
     try:
         trainer.train(1)
-    except AssertionError:
+    except ZeroDivisionError:
         passed = True
 
     assert passed, "The empty dataset assertion has not been raised"

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -179,7 +179,7 @@ def test_early_stopping():
 
 
 def test_empty_dataset():
-    core.init(params=[])
+    core.init()
     game, data = MockGame(), EmptyDataset()
     trainer = core.Trainer(
         game=game,
@@ -188,5 +188,5 @@ def test_empty_dataset():
         validation_data=data,
     )
 
-    with pytest.raises(ZeroDivisionError):
-        trainer.train(1)
+    # should warn user of zero sized batch
+    trainer.train(1)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -188,5 +188,5 @@ def test_empty_dataset():
         validation_data=data,
     )
 
-    with pytest.raises(ZeroDivisionError) as e_info:
+    with pytest.raises(ZeroDivisionError):
         trainer.train(1)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 from pathlib import Path
 
+import pytest
 import torch
 from torch.nn import functional as F
 
@@ -187,10 +188,5 @@ def test_empty_dataset():
         validation_data=data,
     )
 
-    passed = False
-    try:
+    with pytest.raises(ZeroDivisionError) as e_info:
         trainer.train(1)
-    except ZeroDivisionError:
-        passed = True
-
-    assert passed, "The empty dataset assertion has not been raised"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,312 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import random
+import sys
+from pathlib import Path
+
+import torch
+
+import egg.core as core
+from egg.core import Callback
+
+sys.path.insert(0, Path(__file__).parent.parent.resolve().as_posix())
+
+batch_size = 16
+data_size = 10
+
+BATCH_X = torch.zeros((batch_size, data_size))
+BATCH_Y = torch.ones(batch_size).long()
+
+
+class Dataset:
+    def __init__(self, batch_size):
+        self.batch_size = batch_size
+
+    def __iter__(self):
+        for batch in range(self.batch_size):
+            batch_x = BATCH_X[batch]
+            batch_y = BATCH_Y[batch]
+
+            yield (batch_x, batch_y)
+
+
+class AssertCallback(Callback):
+    def __init__(self, mode):
+
+        if mode == 1:
+            self.on_epoch_end = self.on_epoch_end_mixed
+
+        elif mode == 3:
+            self.on_epoch_end = self.on_epoch_end_mixed
+
+    def on_epoch_end_mixed(self, loss: float, logs: core.Interaction, epoch: int):
+
+        assert logs.sender_input.shape == torch.Size([batch_size, data_size])
+        if logs.receiver_input is not None:
+            assert logs.receiver_input.shape == torch.Size([batch_size])
+
+    def on_epoch_end(self, loss: float, logs: core.Interaction, epoch: int):
+        pass
+
+
+class MockGame(torch.nn.Module):
+    def __init__(self, mode):
+        super(MockGame, self).__init__()
+        self.param = torch.nn.Parameter(torch.Tensor([0]))
+        if mode == 0:
+            # list check
+            self.forward = self.forward_list
+        elif mode == 1:
+            self.forward = self.forward_mixed_types
+
+        elif mode == 2:
+            self.forward = self.forward_empty
+        elif mode == 3:
+            self.forward = self.forward_mixed_none
+        elif mode == 4:
+            self.forward = self.forward_mixed_dimension_list
+        elif mode == 5:
+            self.forward = self.forward_mixed_data_types
+        elif mode == 3:
+            self.forward = self.forward_mixed_none
+
+    def forward_list(self, *args, **kwargs):
+        """
+        Test for interaction made of list only
+        """
+        interaction = core.Interaction(
+            sender_input=args[0].tolist(),
+            receiver_input=args[1].tolist(),
+            labels=list(range(10)),
+            message=list(range(10)),
+            receiver_output=list(range(10)),
+            message_length=list(range(10)),
+            aux_input=dict(
+                prov=list(range(10)),
+            ),
+            aux=dict(
+                prov=list(range(10)),
+            ),
+        )
+        return self.param, interaction
+
+    def forward_mixed_types(self, *args, **kwargs):
+        """
+        Test for interaction made of list and torch tensors
+        """
+        interaction = core.Interaction(
+            sender_input=args[0],
+            receiver_input=args[1],
+            labels=list(range(10)),
+            message=list(range(10)),
+            receiver_output=list(range(10)),
+            message_length=list(range(10)),
+            aux_input=dict(
+                prov=list(range(10)),
+            ),
+            aux=dict(
+                prov=list(range(10)),
+            ),
+        )
+        return self.param, interaction
+
+    def forward_empty(self, *args, **kwargs):
+        """
+        Test for interaction made of list and torch tensors
+        """
+
+        if random.uniform(0, 1) > 0.5:
+
+            interaction = core.Interaction(
+                sender_input=args[0],
+                receiver_input=args[1],
+                labels=list(range(10)),
+                message=list(range(10)),
+                receiver_output=list(range(10)),
+                message_length=list(range(10)),
+                aux_input=dict(
+                    prov=list(range(10)),
+                ),
+                aux=dict(
+                    prov=list(range(10)),
+                ),
+            )
+        else:
+            interaction = core.Interaction.empty()
+        return self.param, interaction
+
+    def forward_mixed_none(self, *args, **kwargs):
+        """
+        Test for interaction made of list and torch tensors
+        """
+
+        interaction = core.Interaction(
+            sender_input=args[0],
+            receiver_input=None,
+            labels=list(range(10)),
+            message=None,
+            receiver_output=None,
+            message_length=list(range(10)),
+            aux_input=dict(
+                prov=list(range(10)),
+            ),
+            aux={},
+        )
+        return self.param, interaction
+
+    def forward_mixed_dimension_list(self, *args, **kwargs):
+        """
+        Test for interaction made of list and torch tensors
+        """
+        sender_input = args[0].tolist()
+        receiver_input = args[0].tolist()
+
+        if random.uniform(0, 1) > 0.5:
+            sender_input = sender_input[: batch_size // 2]
+            receiver_input = receiver_input[: batch_size // 2]
+
+        interaction = core.Interaction(
+            sender_input=sender_input,
+            receiver_input=receiver_input,
+            labels=None,
+            message=None,
+            receiver_output=None,
+            message_length=None,
+            aux_input=None,
+            aux={},
+        )
+        return self.param, interaction
+
+    def forward_mixed_data_types(self, *args, **kwargs):
+        """
+        Test for interaction made of list and torch tensors
+        """
+        sender_input = args[0]
+        receiver_input = args[0]
+
+        if random.uniform(0, 1) > 0.5:
+            sender_input = sender_input.tolist()
+            receiver_input = receiver_input.tolist()
+
+        interaction = core.Interaction(
+            sender_input=sender_input,
+            receiver_input=receiver_input,
+            labels=None,
+            message=None,
+            receiver_output=None,
+            message_length=None,
+            aux_input=None,
+            aux={},
+        )
+        return self.param, interaction
+
+
+def test_list_interaction():
+    core.init(params=[])
+    mode = 0
+    game = MockGame(mode=mode)
+    optimizer = torch.optim.Adam(game.parameters())
+
+    data = Dataset(batch_size=batch_size)
+    trainer = core.Trainer(
+        game,
+        optimizer,
+        train_data=data,
+        callbacks=[AssertCallback(mode=mode)],
+    )
+    trainer.train(1)
+
+
+def test_mixed_interaction():
+    core.init(params=[])
+    mode = 1
+    game = MockGame(mode=mode)
+    optimizer = torch.optim.Adam(game.parameters())
+
+    data = Dataset(batch_size=batch_size)
+    trainer = core.Trainer(
+        game,
+        optimizer,
+        train_data=data,
+        callbacks=[AssertCallback(mode=mode)],
+    )
+    trainer.train(1)
+
+
+def test_empty_interaction():
+    core.init(params=[])
+    mode = 2
+    game = MockGame(mode=mode)
+    optimizer = torch.optim.Adam(game.parameters())
+
+    data = Dataset(batch_size=batch_size)
+    trainer = core.Trainer(
+        game,
+        optimizer,
+        train_data=data,
+        callbacks=[AssertCallback(mode=mode)],
+    )
+    trainer.train(1)
+
+
+def test_mixed_none():
+    core.init(params=[])
+    mode = 3
+    game = MockGame(mode=mode)
+    optimizer = torch.optim.Adam(game.parameters())
+
+    data = Dataset(batch_size=batch_size)
+    trainer = core.Trainer(
+        game,
+        optimizer,
+        train_data=data,
+        callbacks=[AssertCallback(mode=mode)],
+    )
+    trainer.train(1)
+
+
+def test_mixed_dimension_list():
+    core.init(params=[])
+    mode = 4
+    game = MockGame(mode=mode)
+    optimizer = torch.optim.Adam(game.parameters())
+
+    data = Dataset(batch_size=batch_size)
+    trainer = core.Trainer(
+        game,
+        optimizer,
+        train_data=data,
+        callbacks=[AssertCallback(mode=mode)],
+    )
+    passed = False
+    try:
+        trainer.train(1)
+    except RuntimeError:
+        passed = True
+
+    assert passed, "Mixed dimension test did not pass"
+
+
+def test_mixed_data_type():
+    core.init(params=[])
+    mode = 5
+    game = MockGame(mode=mode)
+    optimizer = torch.optim.Adam(game.parameters())
+
+    data = Dataset(batch_size=batch_size)
+    trainer = core.Trainer(
+        game,
+        optimizer,
+        train_data=data,
+        callbacks=[AssertCallback(mode=mode)],
+    )
+
+    passed = False
+    try:
+        trainer.train(1)
+    except RuntimeError:
+        passed = True
+
+    assert passed, "Mixed dimension test did not pass"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,7 +45,10 @@ class AssertCallback(Callback):
 
         assert logs.sender_input.shape == torch.Size([batch_size, data_size])
         if logs.receiver_input is not None:
-            assert logs.receiver_input.shape == torch.Size([batch_size])
+            if isinstance(logs.receiver_input, torch.Tensor):
+                assert logs.receiver_input.shape == torch.Size([batch_size])
+            else:
+                assert len(logs.receiver_input) == batch_size
 
     def on_epoch_end(self, loss: float, logs: core.Interaction, epoch: int):
         pass
@@ -60,7 +63,6 @@ class MockGame(torch.nn.Module):
             self.forward = self.forward_list
         elif mode == 1:
             self.forward = self.forward_mixed_types
-
         elif mode == 2:
             self.forward = self.forward_empty
         elif mode == 3:
@@ -69,8 +71,6 @@ class MockGame(torch.nn.Module):
             self.forward = self.forward_mixed_dimension_list
         elif mode == 5:
             self.forward = self.forward_mixed_data_types
-        elif mode == 3:
-            self.forward = self.forward_mixed_none
 
     def forward_list(self, *args, **kwargs):
         """
@@ -98,7 +98,7 @@ class MockGame(torch.nn.Module):
         """
         interaction = core.Interaction(
             sender_input=args[0],
-            receiver_input=args[1],
+            receiver_input=float(args[1]),
             labels=list(range(10)),
             message=list(range(10)),
             receiver_output=list(range(10)),
@@ -121,7 +121,7 @@ class MockGame(torch.nn.Module):
 
             interaction = core.Interaction(
                 sender_input=args[0],
-                receiver_input=args[1],
+                receiver_input=float(args[1]),
                 labels=list(range(10)),
                 message=list(range(10)),
                 receiver_output=list(range(10)),
@@ -184,7 +184,7 @@ class MockGame(torch.nn.Module):
         Test for interaction made of list and torch tensors
         """
         sender_input = args[0]
-        receiver_input = args[0]
+        receiver_input = args[1]
 
         if random.uniform(0, 1) > 0.5:
             sender_input = sender_input.tolist()


### PR DESCRIPTION
- The use_info_table bool parameter was not taken into consideration when updating the infotable at the end of the train/val epoch. This resulted in an error when trying to update such table without having instantiated it in the first place.

Problem: The logging strategy class takes no consideration of the current batch id.

Desired outcome: It can be desirable to log information based on the batch_id (typically with the formula batch_id%logging_step) when dealing with large data types such as images.

Proposed Solution: in this PR, this issue is addressed by moving the logging strategy call outside the game forward pass. In this instance the game returns a complete interaction that is then filtered with the logging strategy. For this reason a new attribute has been included in the logging strategy class which is the batch id. Moreover a filtering pass had been added inside the from_iterable method of the Interaction class. This filtering is based on a new method is_empty that checks if the current interaction is empty.

