### PR TITLE
fix nest error when using false boolean params

### DIFF
--- a/egg/nest/common.py
+++ b/egg/nest/common.py
@@ -26,7 +26,7 @@ def parse_json_sweep(config):
 
     commands = []
     for p in perms:
-        args = [to_arg(k, p[i]) for i, k in enumerate(config.keys())]
+        args = [to_arg(k, p[i]) for i, k in enumerate(config.keys()) if to_arg(k, p[i])]
         commands.append(args)
     return commands
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR allows to pass boolean parameters to nest setting them as either true or false when using json files.

<!--- Describe your changes in detail -->
When setting a nest parameter  in a json file as false this will simply be ignored by the json file parser nest utility method.
