### PR TITLE
Add note to vocab_size param

### DIFF
--- a/egg/core/reinforce_wrappers.py
+++ b/egg/core/reinforce_wrappers.py
@@ -684,7 +684,7 @@ class TransformerSenderReinforce(nn.Module):
         :param agent: the agent to be wrapped, returns the "encoder" state vector, which is the unrolled into a message
         :param vocab_size: vocab size of the message
         :param embed_dim: embedding dimensions
-        :param max_len: maximal length of the message (including <eos>)
+        :param max_len: maximal length of the message
         :param num_layers: number of transformer layers
         :param num_heads: number of attention heads
         :param hidden_size: size of the FFN layers

--- a/egg/core/util.py
+++ b/egg/core/util.py
@@ -99,7 +99,7 @@ def _populate_cl_params(arg_parser: argparse.ArgumentParser) -> argparse.Argumen
         "--vocab_size",
         type=int,
         default=10,
-        help="Number of symbols (terms) in the vocabulary (default: 10)",
+        help="Number of symbols (terms) in the vocabulary (default: 10) (including the end-of-sequence symbol <eos>) ",
     )
     arg_parser.add_argument(
         "--max_len", type=int, default=1, help="Max length of the sequence (default: 1)"


### PR DESCRIPTION
Explicitly mention that the vocab_size includes the EOS token.

Thanks for working on EGG and opening a PR!
Please fill this template to help us understand what are you introducing in EGG.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Explicitly mention that the vocab_size includes the EOS token.

## Related Issue (if any)
https://github.com/facebookresearch/EGG/issues/246

## Motivation and Context
https://github.com/facebookresearch/EGG/issues/246

## How Has This Been Tested?
N./A.
