### PR TITLE
Topsim fix

### DIFF
--- a/egg/core/language_analysis.py
+++ b/egg/core/language_analysis.py
@@ -206,7 +206,8 @@ class TopographicSimilarity(Callback):
         messages = logs.message.argmax(dim=-1) if self.is_gumbel else logs.message
         messages = [msg.tolist() for msg in messages]
 
-        topsim = self.compute_topsim(logs.sender_input, messages)
+        topsim = self.compute_topsim(logs.sender_input, messages,
+                                     self.sender_input_distance_fn, self.message_distance_fn)
 
         output = json.dumps(dict(topsim=topsim, mode=mode, epoch=epoch))
         print(output, flush=True)

--- a/egg/core/language_analysis.py
+++ b/egg/core/language_analysis.py
@@ -205,8 +205,9 @@ class TopographicSimilarity(Callback):
     def print_message(self, logs: Interaction, mode: str, epoch: int) -> None:
         messages = logs.message.argmax(dim=-1) if self.is_gumbel else logs.message
         messages = [msg.tolist() for msg in messages]
+        sender_input = torch.flatten(logs.sender_input, start_dim=1)
 
-        topsim = self.compute_topsim(logs.sender_input, messages,
+        topsim = self.compute_topsim(sender_input, messages,
                                      self.sender_input_distance_fn, self.message_distance_fn)
 
         output = json.dumps(dict(topsim=topsim, mode=mode, epoch=epoch))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The TopographicSimilarity class wasn't using the functions `sender_input_distance_fn` and `message_distance_fn` given in `__init__`. In addition, it couldn't work for `sender_input`s of more than 1D (e.g., images), because the Spearman correlation function expects 2D input. Fixed both in the `print_message` method.

## Description
1. Added `self.sender_input_distance_fn` and `self.message_distance_fn` to the `self.compute_topsim` call inside the `print_message` method.
2. Flattened `sender_input` to be 2D inside the `print_message` method.

## Related Issue
https://github.com/facebookresearch/EGG/issues/250
<!--- If suggesting a new feature or change, it would be great to discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
