### PR TITLE
Fixes calculation of accuracy for the signal game with GumbelSoftmax

### DIFF
--- a/egg/zoo/signal_game/train.py
+++ b/egg/zoo/signal_game/train.py
@@ -67,7 +67,7 @@ def loss_nll(
     NLL loss - differentiable and can be used with both GS and Reinforce
     """
     nll = F.nll_loss(receiver_output, labels, reduction="none")
-    acc = (labels == receiver_output.argmax(dim=1)).float().mean()
+    acc = (labels == receiver_output.argmax(dim=1)).float()
     return nll, {"acc": acc}
 
 


### PR DESCRIPTION
## Description
Fix the calculation of the accuracy when running the signal game with GumbelSoftmax. 
Here, the mean of the accuracies for the batch was calculated already in the loss function, although it should be only calculated in the `forward` call of the game.

## Related Issue (if any)
Issue   #256 

## Motivation and Context
Signal game can be run using GumbelSoftmax (see Issue #256)

## How Has This Been Tested?
Error is fixed and the agents are trained on the data, using GumbelSoftmax.
